### PR TITLE
Ensure Ansible trigger installs dependencies automatically

### DIFF
--- a/tools/ansible/trigger_playbook.sh
+++ b/tools/ansible/trigger_playbook.sh
@@ -5,7 +5,6 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m' # Keine Farbe
 
-
 # Variablen zuweisen
 tools_dir="$1"      # Tools-Verzeichnis
 config_file="$2"    # Konfigurationsdatei
@@ -16,16 +15,35 @@ start_playbook() {
     local playbookname=$1
     local playbookfolder=$2
     echo -e "${GREEN}Running Ansible ${playbookfolder}/${playbookname}...${NC}"
-    ANSIBLE_CONFIG=$tools_dir/ansible/${playbookfolder}/ansible.cfg ansible-playbook -i $tools_dir/ansible/${playbookfolder}/hosts.ini $tools_dir/ansible/${playbookfolder}/playbooks/${playbookname} --extra-vars "CONFIG_YAML=$config_file"
+    ANSIBLE_CONFIG="$tools_dir/ansible/${playbookfolder}/ansible.cfg" \
+        ansible-playbook \
+        -i "$tools_dir/ansible/${playbookfolder}/hosts.ini" \
+        "$tools_dir/ansible/${playbookfolder}/playbooks/${playbookname}" \
+        --extra-vars "CONFIG_YAML=$config_file"
 }
 
+# Sicherstellen, dass ansible-playbook verfügbar ist
+if ! command -v ansible-playbook &> /dev/null; then
+    echo -e "${RED}Ansible ist nicht installiert. Führe Installationsskript aus...${NC}"
+    if [ -x "$tools_dir/ansible/install_ansible.sh" ]; then
+        bash "$tools_dir/ansible/install_ansible.sh"
+    else
+        echo -e "${RED}Installationsskript für Ansible nicht gefunden: $tools_dir/ansible/install_ansible.sh${NC}"
+        exit 1
+    fi
+fi
+
 # Überprüfen, ob Docker installiert ist
-if ! command -v docker &> /dev/null
-then
+if ! command -v docker &> /dev/null; then
     echo -e "${RED}Docker ist nicht installiert. Führe Installationsskript aus...${NC}"
-    bash "$tools_dir/docker/install_docker.sh"
-    start_playbook "$ansibleName.yml" "$ansibleFolder"
+    if [ -x "$tools_dir/docker/install_docker.sh" ]; then
+        bash "$tools_dir/docker/install_docker.sh"
+    else
+        echo -e "${RED}Docker-Installationsskript nicht gefunden: $tools_dir/docker/install_docker.sh${NC}"
+        exit 1
+    fi
 else
     echo -e "${GREEN}Docker ist bereits installiert.${NC}"
-    start_playbook "$ansibleName.yml" "$ansibleFolder"
 fi
+
+start_playbook "$ansibleName.yml" "$ansibleFolder"


### PR DESCRIPTION
## Summary
- ensure the Ansible trigger installs Ansible automatically when `ansible-playbook` is missing
- harden Docker check in the trigger script so missing installer script aborts early
- keep playbook invocation logic intact while formatting command for readability

## Testing
- bash -n tools/ansible/trigger_playbook.sh

------
https://chatgpt.com/codex/tasks/task_e_68d2d18fe71c8333832313f077c4bccf