### PR TITLE
docs: SOT als natives Java-CLI (Quarkus+GraalVM) — Nix-Substrat, App-Manager, Cross-Platform (Linux/macOS/Windows-WSL)

### DIFF
--- a/docs/java-quarkus-appmanager-brief.md
+++ b/docs/java-quarkus-appmanager-brief.md
@@ -1,0 +1,439 @@
+# SOT Dynamic App-Manager + Delivery — Consolidated Design Brief
+
+Source: 4 architecture agents (app-model-and-catalog, update-monitoring, app-selector-cli-ux, gradle-justfile-github-install). Java/Quarkus/GraalVM native CLI `sot`.
+
+---
+
+## 1. Per-Area Design
+
+### 1.1 app-model-and-catalog  *(effort: L)*
+
+New package `de.jklein.sot.app` resolves the closed-world tension by splitting two axes Bash conflated: WHERE app definitions come from (`CatalogSource`, 100% runtime data) vs HOW an app is fetched/installed/version-checked (`InstallStrategy`, a fixed compiled-in CDI bean set). Adding an app = drop an `app.yml` into a catalog (zero rebuild); adding a strategy = add a bean (rebuild). This subsumes the old §1.4 CapabilityProvider layer: `ExtensionManifest`→`AppManifest`; `LocalDirectoryProvider`→a `bundled` CatalogSource over embedded `apps/**/app.yml`; `RemoteGitProvider`→a `git` CatalogSource + `git-repo`/`script` strategies; AAT/TID become two `app.yml` entries with a `runner:` block; `CapabilityStateStore`→`InstalledAppStore`, `CapabilityService`→`AppService`. Data model is immutable `@RegisterForReflection` records; `SourceSpec` carries an `AppSourceType` discriminator + raw `JsonNode options` (each strategy binds its own slice in `resolve()`, avoiding native-hostile Jackson `@JsonSubTypes`). `AppCatalog` (@ApplicationScoped) fetches each CatalogSource at runtime (git via `GitService`, http-index via JDK `HttpClient`, bundled via `AssetExtractor`), parses `index.yml`+manifests through the shared `YAMLMapper`, merges by `priority` into `Map<AppId,AppManifest>`, TTL-cached under `SotPaths.cacheRoot/catalog`. `InstalledAppStore` round-trips `installed.yml` (0600, temp+ATOMIC_MOVE). `AppService` is the single lifecycle owner (list/install with topo-resolved `requires.apps`/update/upgrade --all/remove/pin/unpin/outdated), dispatching to five strategies (git-repo, docker-compose, github-release-binary, apt-deb, script) that delegate to shared `ProcessRunner`/`GitService`/`GitHubReleaseClient`/`ChecksumVerifier`. `outdated()` fans `queryLatest()` across virtual threads, comparing a compiled `SemVer`.
+
+Key components:
+- `AppManifest` — record — typed model of `app.yml`; apiVersion+id+SourceSpec/VersionSpec/Requires/InstallSpec/RunnerSpec; @RegisterForReflection; subsumes ExtensionManifest/module.yml.
+- `SourceSpec` — record — AppSourceType discriminator + raw JsonNode options; per-strategy typed binding, avoids Jackson polymorphism.
+- `AppSourceType` — enum — GIT_REPO, DOCKER_COMPOSE, GITHUB_RELEASE_BINARY, APT_DEB, SCRIPT; maps 1:1 to a strategy bean.
+- `InstallStrategy` — interface — THE single SPI: type()/resolve()/install()/update()/remove()/queryLatest(); five @ApplicationScoped beans, discovered `@All` at build time.
+- `GitRepoStrategy / DockerComposeStrategy / GithubReleaseBinaryStrategy / AptDebStrategy / ScriptStrategy` — CDI-bean — the five compiled-in strategies; each delegates to shared ProcessRunner/GitService/GitHubReleaseClient/ChecksumVerifier.
+- `AppCatalog` — CDI-bean — fetches all CatalogSources at runtime, parses+merges manifests by priority into one index; TTL-cached, refreshable.
+- `CatalogSource` — record — runtime-configured origin (id, type git|http-index|bundled, url, ref, priority, trust); from SotConfig, not compiled in.
+- `CatalogIndex` — record — parsed `index.yml`: app id→manifest path (+denormalised latest version) for fast listing.
+- `InstalledAppStore` — CDI-bean — typed round-trip of `installed.yml`; atomic 0600 writes; replaces CapabilityStateStore.
+- `InstalledApp` — record — per-app installed state: id, installedVersion, sourceType, sourceRef, catalogSourceId, installPath, pinned, pinnedVersion, timestamps, checksum.
+- `AppService` — CDI-bean — single lifecycle owner: list/search/info/install/update/upgrade/remove/pin/unpin/outdated + topo-resolution + strategy dispatch; replaces CapabilityService.
+- `AppStatus` — enum — joined catalog∪installed verdict: NOT_INSTALLED / INSTALLED / OUTDATED / PINNED.
+- `SemVer` — record — compiled-in parse+compare+constraint match (no reflection); powers outdated + version.constraint gating.
+- `RunnerSpec` — record — optional manifest block marking an app as an ansible/runner extension (AAT/TID roles+playbooks).
+- `AppCommand` — @Command — picocli parent `sot app` (alias `ex` filters role=runner) with install/update/remove/pin/list/outdated/catalog subcommands + interactive selector.
+
+### 1.2 update-monitoring  *(effort: L)*
+
+Package `de.jklein.sot.app.update`, sibling to the App/catalog layer. Core seam is a closed-world `VersionResolver` SPI: one compiled-in strategy per source type, injected `@All List<VersionResolver>`, indexed by an `UpdateStrategy` enum (GITHUB_RELEASE, GIT_TAG, DOCKER_IMAGE, APT, SCRIPT). The SET of strategies is fixed/compiled; WHICH apps/repos/tag-patterns/pins exist is runtime data from each manifest `update:` block. `UpdateMonitorService` (@ApplicationScoped) is the single owner: `checkAll(CheckOptions)` reads installed apps via read-only port `InstalledApps`, builds a `VersionQuery` per app, dispatches to the matching resolver concurrently over virtual threads (StructuredTaskScope + semaphore), and folds into an `OutdatedReport`; any per-app failure degrades to `UpdateStatus.UNKNOWN`, never aborting. Resolvers return `ResolvedVersion` (optional parsed `Version` + raw tag + optional digest); a hand-rolled native-safe `Version`/`VersionConstraint` implements semver precedence. Pinning lives in user state, not the manifest: EXACT pin→PINNED (frozen), RANGE pin→UPDATE_AVAILABLE only for a newer satisfying version; non-semver apps (calver/sha/`:latest`) compare by equality/digest, with an optional `tagPattern` regex extracting a version. `VersionCache` persists per-`cacheKey(appId+strategy+paramsHash)` to `update-cache.yml`; HTTP resolvers issue conditional GETs (If-None-Match), 304→HIT, rate-limit→serve-stale+RATE_LIMITED. The binary is NOT a daemon: bootstrap installs a systemd timer (`sot-update-check.timer`→`.service` running `sot app check --quiet --notify`), cron fallback; the tick writes `last-check.json` and `UpdateNotifier` emits only on state-change. `sot app status`/`outdated` read `last-check.json` for instant offline display unless `--refresh`.
+
+Key components:
+- `VersionResolver` — interface (SPI) — strategy per source type; resolves LATEST for a VersionQuery; fixed compiled-in set, @All List-injected, discriminated by UpdateStrategy.
+- `GitHubReleaseResolver` — CDI-bean — GitHub Releases API (latest non-draft/non-prerelease) via JDK HttpClient, ETag conditional GET + rate-limit aware.
+- `GitTagResolver` — CDI-bean — `git ls-remote --tags` via ProcessRunner, filters by tagPattern, semver-sorts.
+- `DockerImageResolver` — CDI-bean — registry v2 tag/manifest digest (bearer-token dance for ghcr/dockerhub); compares by digest for mutable tags.
+- `AptPolicyResolver` — CDI-bean — `apt-cache policy <pkg>` via ProcessRunner (installed vs candidate).
+- `ScriptResolver` — CDI-bean — executes a manifest-declared command whose stdout is the latest version (data-driven escape hatch).
+- `UpdateMonitorService` — CDI-bean — single owner: dispatches resolvers concurrently, computes outdated status, builds OutdatedReport, degrades to UNKNOWN.
+- `VersionCache` — CDI-bean — persistent per-app cache (etag/last-modified/ttl/lastLatest) for conditional requests, serve-stale, offline reads.
+- `Version / VersionConstraint` — record + comparator — native-safe semver parse/precedence + pin constraint (EXACT vs RANGE); equality fallback.
+- `AppUpdateReport / OutdatedReport` — record — per-app status + aggregate counts + generatedAt.
+- `UpdateScheduler / UpdateNotifier` — CDI-bean — bootstrap-installed systemd timer (cron fallback); change-only summary to console/file/hook.
+- `InstalledApps` — interface (port) — read-only view of installed apps (appId, installedVersion, digest, pin); the only cross-layer coupling.
+
+### 1.3 app-selector-cli-ux  *(effort: L)*
+
+The `sot app` surface is the tool's front door and single vocabulary subsuming old extensions/plugins/capability commands; an "App" is a catalog entry whose SourceType is one of the fixed strategies. Package `de.jklein.sot.cli.app`. One picocli parent `AppCommand` (@Command name="app", aliases {apps,a}) declares the subcommand tree; run bare on a TTY it launches the interactive App-Selektor via its Callable, run bare without a TTY it prints `list` (never blocks a script). Every subcommand is a CDI bean constructor-injecting `AppService` + `ConsoleService` + `ProgressReporter`. Subcommands: browse/select, list (ls), search, info, install (add,i), update (up), outdated (stale), remove (rm,uninstall), pin, unpin, refresh (sync), status. Automation flags live on `AppCommand` scope=INHERIT: `--json`, `--yes/-y`, `--no-color`, `--catalog <url>`, `--dry-run`. The selector `AppSelector` is deliberately line-oriented (NOT a raw-mode TUI): it renders a numbered table via `ConsoleService` and loops on a `BufferedReader` over stdin (numbers toggle multi-select, `/query` fuzzy-filter, `a` all, `i` install, `u` update, enter confirm, q quit); `AppStatus` (AVAILABLE/INSTALLED/OUTDATED/PINNED/BROKEN) drives colored glyphs. On confirm it builds a `SelectionOutcome`, delegates to `AppService`, streams per-app progress through `ProgressReporter`/`ProgressSink`. No JLine/ncurses/`stty` — trivially GraalVM-native-safe; `System.console()==null` (piped) → selector refuses. `AppService` is the renamed/expanded `CapabilityService`; `sot extensions`/`sot plugins` remain thin deprecated alias commands forwarding to `app list`/`app install`.
+
+Key components:
+- `AppCommand` — @Command — parent `sot app` (aliases apps,a); subcommand tree + inherited automation flags; bare-on-TTY launches AppSelector, bare-piped prints list.
+- `AppSelectCommand` — @Command — `sot app browse|select`: explicit interactive entry instantiating AppSelector with full catalog view.
+- `AppSelector` — class — native-safe line-oriented engine: numbered table + BufferedReader(stdin) toggle/filter/action loop → SelectionOutcome; no raw-mode/JLine.
+- `AppTableRenderer` — class — formats ordered List<AppView> into numbered, column-aligned glyph+color table (also the `list` output).
+- `AppStatus` — enum — AVAILABLE/INSTALLED/OUTDATED/PINNED/BROKEN → glyph+color; single source for selector and list/outdated.
+- `SelectionState` — class — mutable per-session model: filter query, toggled name set, visible-row index map; fuzzy-matches summary+name.
+- `AppListCommand / AppSearchCommand / AppInfoCommand / AppOutdatedCommand / AppStatusCommand` — @Command — non-interactive read verbs, honor --json; AppOutdatedCommand is the monitoring surface.
+- `AppInstallCommand / AppUpdateCommand / AppRemoveCommand` — @Command — mutating verbs (names/--all, --yes/--dry-run); delegate to AppService + stream ProgressReporter.
+- `AppPinCommand / AppUnpinCommand / AppRefreshCommand` — @Command — pin/unpin exclude/include from updates; refresh re-pulls catalog index.
+- `ExtensionsCommand / PluginsCommand` — @Command — deprecated thin aliases forwarding to app list/install with a deprecation notice.
+- `AppNameCandidates` — class — picocli Iterable<String> completionCandidates reading local catalog cache at runtime; @RegisterForReflection.
+- `AppService` — interface (consumed) — collaborator from the app/catalog layer (renamed CapabilityService); the single lifecycle owner this UX injects.
+
+### 1.4 gradle-justfile-github-install  *(effort: L)*
+
+Build + delivery migrate from Maven to a single-module Gradle (Groovy DSL) build and a GitHub-Release-fed native install path. Bootstrap: `quarkus create cli de.jklein.sot:sot --gradle -x picocli` emits `settings.gradle`, `build.gradle`, `gradle.properties`, and the Gradle wrapper; every `mvnw`/`pom.xml` reference is replaced 1:1 (`./mvnw -B verify`→`./gradlew check`, `./mvnw install -Dnative`→`./gradlew build -Dquarkus.native.enabled=true`). `build.gradle` applies `plugins { java; io.quarkus; com.diffplug.spotless; jacoco; org.jreleaser }`, pins the platform via `enforcedPlatform("io.quarkus.platform:quarkus-bom:${quarkusPlatformVersion}")`. Native flags — `quarkus.native.builder-image` (pinned Mandrel/UBI9) + `-H:+StaticExecutableWithDynamicLibC` (mostly-static glibc, resolving D1 vs musl) — live in `application.properties`, not the build file. A root `Justfile` is the human entrypoint (setup/dev/build/native/test/lint/fmt/run/install-local/release/clean), shelling to `./gradlew` (CI calls Gradle directly). Delivery has two tiers: Tier 1 = one-liner `curl -fsSL .../install.sh | bash`; `install.sh` (the ONLY shell, shellcheck-gated) detects os/arch via `uname`, resolves the release tag (arg/`SOT_VERSION`/GitHub API), downloads `sot-<os>-<arch>` + `.sha256` (+ cosign `.sig`/`.pem`), verifies checksum then cosign keyless, and `install -m755`s to `/usr/local/bin/sot` or `~/.local/bin` fallback. Tier 2 = in-binary `sot self-update` reusing the same asset/verify contract. CI: `native-build.yml` (reusable matrix, glibc runners ubuntu-24.04 amd64 + arm) builds+smoke-tests each binary; `release.yml` (tag `v*`) runs `./gradlew jreleaserFullRelease` to produce checksums, Syft SBOM, cosign signatures and the GitHub Release.
+
+Key components:
+- `build.gradle` — config — single-module build: io.quarkus+spotless+jacoco+jreleaser plugins, enforcedPlatform quarkus-bom, all extensions as deps; replaces pom.xml.
+- `settings.gradle` — config — rootProject.name='sot' + pluginManagement resolving io.quarkus from pinned platform.
+- `gradle.properties` — config — pins quarkusPlatform{GroupId,ArtifactId,Version} + plugin version; single version source.
+- `gradlew + gradle/wrapper` — config — pinned Gradle wrapper; replaces mvnw/.mvn.
+- `Justfile` — config — human recipes wrapping ./gradlew.
+- `install.sh` — resource — the only remaining shell: uname detect, resolve tag, download+verify(sha256+cosign), install -m755 to /usr/local/bin or ~/.local/bin fallback, print next steps.
+- `.github/workflows/native-build.yml` — config — reusable workflow_call matrix over glibc runners; builds+smokes+uploads each sot-<os>-<arch>.
+- `.github/workflows/release.yml` — config — on tag v*: invoke native-build, collect binaries, run gradlew jreleaserFullRelease.
+- `.github/workflows/ci.yml` — config — PR/push gate: gradlew check (Spotless+JaCoCo+tests), shellcheck install.sh, one linux-amd64 native smoke.
+- `jreleaser config` — config — NATIVE_IMAGE distributions per os/arch, checksum, Syft SBOM, cosign signing, GitHub Releases publisher.
+- `.pre-commit-config.yaml` — config — Spotless, shellcheck/shfmt on install.sh, yamllint, ansible-lint, gitleaks.
+
+---
+
+## 2. Concrete Schemas & Interfaces
+
+### 2.1 `app.yml` — the declarative unit (source.type picks the strategy)
+```yaml
+apiVersion: sot.dev/v1
+kind: App
+id: grafana                 # catalog-unique stable id
+name: Grafana
+description: Monitoring dashboards
+category: observability
+labels: [monitoring, ui]
+source:
+  type: docker-compose      # git-repo|docker-compose|github-release-binary|apt-deb|script
+  repoUrl: https://github.com/owner/grafana-stack
+  ref: v10.4.0              # tag/branch/commit
+  composeFile: docker-compose.yml
+version:
+  strategy: compose-image-tag # git-tag|github-release|compose-image-tag|apt-policy|static|script
+  constraint: '>=10.0.0 <11.0.0'
+requires:
+  tools: [docker]
+  apps:  [prometheus]        # topo-ordered before install
+  os:    [debian, ubuntu]
+install:
+  path: '{appsRoot}/grafana' # templated via SotPaths
+  env:  { GF_PORT: '3000' }
+  hooks: { postInstall: scripts/post.sh }
+runner:                      # OPTIONAL — present => app is an AAT/TID-style extension
+  playbooks: [site.yml]
+```
+
+### 2.2 `index.yml` — a CatalogSource's manifest listing
+```yaml
+apiVersion: sot.dev/v1
+kind: CatalogIndex
+apps:
+  - { id: grafana,    manifest: apps/grafana/app.yml,    version: 10.4.0 }
+  - { id: prometheus, manifest: apps/prometheus/app.yml, version: 2.53.0 }
+```
+
+### 2.3 `installed.yml` — typed state store (0600, atomic)
+```yaml
+apiVersion: sot.dev/v1
+kind: InstalledApps
+apps:
+  grafana:
+    installedVersion: 10.3.1
+    sourceType: docker-compose
+    sourceRef: v10.3.1
+    catalogSourceId: owner-catalog
+    installPath: /opt/sot/apps/grafana
+    pinned: false
+    pinnedVersion: null
+    installedAt: 2026-07-01T10:00:00Z
+    lastCheckedAt: 2026-07-07T08:00:00Z
+    checksum: 'sha256:...'
+```
+
+### 2.4 `InstallStrategy` — the ONE strategy interface (5 compiled-in beans, apps are data)
+```java
+public interface InstallStrategy {
+  AppSourceType type();                                     // discriminator
+  ResolvedSource resolve(AppManifest m, InstallContext ctx);// bind+validate source.options
+  InstallOutcome install(ResolvedSource s, InstallContext ctx);
+  InstallOutcome update(ResolvedSource s, InstalledApp cur, InstallContext ctx);
+  void           remove(InstalledApp cur, InstallContext ctx);
+  VersionInfo    queryLatest(ResolvedSource s, InstallContext ctx); // outdated detection
+}
+// wired: @All List<InstallStrategy> -> Map<AppSourceType,InstallStrategy> at build time
+```
+
+### 2.5 `CatalogSource` + `AppService` (app-model area surface)
+```java
+record CatalogSource(String id, CatalogSourceType type, // GIT|HTTP_INDEX|BUNDLED
+  String url, String ref, int priority, CatalogTrust trust) {}
+// AppService surface (app-model-and-catalog)
+interface AppService {
+  List<AppView> list(EnumSet<AppStatus> filter);
+  AppView info(String id); List<AppView> outdated();
+  void install(String id, Optional<String> version);
+  void update(String id); void upgradeAll();
+  void remove(String id); void pin(String id, Optional<String> v); void unpin(String id);
+}
+```
+
+### 2.6 `VersionResolver` SPI + update-report shapes (update-monitoring)
+```java
+interface VersionResolver { UpdateStrategy strategy(); ResolvedVersion resolveLatest(VersionQuery q, ResolverContext ctx); }
+enum UpdateStrategy { GITHUB_RELEASE, GIT_TAG, DOCKER_IMAGE, APT, SCRIPT }
+record VersionQuery(String appId, UpdateStrategy strategy, Map<String,String> params, Optional<VersionConstraint> pin, Optional<String> installedVersion, Optional<String> installedDigest, boolean includePrerelease, Optional<String> tagPattern) {}
+record ResolvedVersion(Optional<Version> latest, String rawLatest, Optional<String> digest, Instant resolvedAt, CacheDisposition cache) {} // CacheDisposition: MISS|HIT|REVALIDATED|RATE_LIMITED
+enum UpdateStatus { UP_TO_DATE, UPDATE_AVAILABLE, PINNED, UNKNOWN, NOT_INSTALLED }
+record AppUpdateReport(String appId, UpdateStatus status, UpdateStrategy strategy, Optional<String> installedVersion, Optional<String> latestVersion, Optional<VersionConstraint> pin, Instant checkedAt, boolean fromCache, Optional<String> error) {}
+record OutdatedReport(Instant generatedAt, List<AppUpdateReport> apps, int upToDate, int updatable, int pinned, int unknown) {}
+sealed interface VersionConstraint { record Exact(Version v) implements VersionConstraint; record Range(String expr) implements VersionConstraint; } // Exact=frozen->PINNED, Range=bounded update
+// VersionCache entry: { cacheKey, appId, strategy, rawLatest, digest, etag, lastModified, resolvedAt, ttl }
+// UpdateMonitorService: OutdatedReport checkAll(CheckOptions); AppUpdateReport check(String appId, CheckOptions); // CheckOptions(refresh, cachedOnly, notify)
+```
+
+### 2.7 App manifest `update:` block (catalog data, no rebuild — update-monitoring)
+```yaml
+update:
+  strategy: github-release   # git-tag | docker-image | apt | script
+  repo: NiklasJavier/myapp   # or image: ghcr.io/.../x, or package: nginx, or command: "myapp --print-latest"
+  tagPattern: '^v(\d+\.\d+\.\d+)$'
+  includePrerelease: false
+  ttl: 6h
+```
+
+### 2.8 CLI-layer `AppCommand` + DTOs (app-selector — note: a SECOND `AppService` shape)
+```java
+@Command(name="app", aliases={"apps","a"}, subcommands={AppSelectCommand.class, AppListCommand.class, AppSearchCommand.class, AppInfoCommand.class, AppInstallCommand.class, AppUpdateCommand.class, AppOutdatedCommand.class, AppRemoveCommand.class, AppPinCommand.class, AppUnpinCommand.class, AppRefreshCommand.class, AppStatusCommand.class})
+class AppCommand implements Callable<Integer> {
+  @Option(names="--json", scope=INHERIT) boolean json;
+  @Option(names={"-y","--yes"}, scope=INHERIT) boolean assumeYes;
+  @Option(names="--catalog", scope=INHERIT) Optional<String> catalogOverride;
+  @Inject AppService apps; @Inject ConsoleService console;
+}
+
+// collaborator injected from the app/catalog layer (app-selector's view of AppService)
+interface AppService { List<AppView> catalog(); List<AppView> installed(); List<AppView> outdated(); AppView info(String name); InstallResult install(String name, InstallOptions o); UpdateResult update(String name); void remove(String name); void pin(String name, Optional<String> version); void unpin(String name); CatalogIndex refresh(); }
+
+record AppView(String name, String summary, AppStatus status, String installedVersion, String latestVersion, boolean pinned, SourceType source) {}
+enum AppStatus { AVAILABLE, INSTALLED, OUTDATED, PINNED, BROKEN }
+class AppSelector { SelectionOutcome run(List<AppView> rows, SelectorMode mode, ProgressReporter progress); }
+record SelectionOutcome(List<String> chosen, SelectorAction action) {}
+enum SelectorAction { INSTALL, UPDATE, REMOVE, CANCEL }
+
+// completion: `sot app install <TAB>` -> live app names from local catalog cache
+class AppNameCandidates implements Iterable<String> { @Inject AppService apps; public Iterator<String> iterator(){ return apps.catalog().stream().map(AppView::name).iterator(); } }
+
+// selector key-loop grammar (line reads, native-safe):
+// <int>[,<int>]  toggle rows | /<query>  fuzzy filter | a all | i install | u update | r remove | enter confirm | q quit
+```
+
+### 2.9 `build.gradle` (Groovy DSL)
+```groovy
+plugins {
+  id 'java'
+  id 'io.quarkus'
+  id 'com.diffplug.spotless' version '6.25.0'
+  id 'jacoco'
+  id 'org.jreleaser' version '1.13.1'
+}
+dependencies {
+  implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+  implementation 'io.quarkus:quarkus-picocli'
+  implementation 'io.quarkus:quarkus-arc'
+  implementation 'io.quarkus:quarkus-jackson'
+  implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+  implementation 'io.quarkus:quarkus-hibernate-validator'
+  implementation 'io.quarkus:quarkus-qute'
+  testImplementation 'io.quarkus:quarkus-junit5'
+  testImplementation 'io.quarkus:quarkus-junit5-mockito'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'net.jqwik:jqwik'
+}
+java { sourceCompatibility = JavaVersion.VERSION_21 }
+spotless { java { googleJavaFormat() } }
+jacoco { toolVersion = '0.8.12' }
+```
+
+### 2.10 `gradle.properties` (single version source)
+```properties
+quarkusPlatformGroupId=io.quarkus.platform
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformVersion=3.37.0
+quarkusPluginId=io.quarkus
+quarkusPluginVersion=3.37.0
+```
+
+### 2.11 `application.properties` (owns native flags, not build.gradle)
+```properties
+quarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21
+quarkus.native.container-build=true
+quarkus.native.additional-build-args=-H:+StaticExecutableWithDynamicLibC  # mostly-static glibc (fork/exec-safe), NOT --libc=musl
+quarkus.native.resources.includes=ansible/**,docker/**,templates/**,config/**,modules/**,assets/manifest.txt
+quarkus.native.add-all-charsets=true
+```
+
+### 2.12 GitHub Release asset-naming contract (install.sh ⇄ jreleaser)
+```
+sot-linux-amd64       sot-linux-amd64.sha256   sot-linux-amd64.sig   sot-linux-amd64.pem
+sot-linux-arm64       sot-linux-arm64.sha256   ...
+checksums_sha256.txt  sbom.syft.json
+```
+
+### 2.13 `install.sh` core flow (bash, set -euo pipefail)
+```bash
+REPO=NiklasJavier/SOT
+os=$(uname -s | tr A-Z a-z)                 # linux|darwin
+arch=$(uname -m); case $arch in x86_64) arch=amd64;; aarch64|arm64) arch=arm64;; esac
+tag=${SOT_VERSION:-$(curl -fsSL https://api.github.com/repos/$REPO/releases/latest | grep -m1 tag_name | cut -d'"' -f4)}
+base=https://github.com/$REPO/releases/download/$tag
+asset=sot-$os-$arch
+curl -fsSL -o "$tmp/$asset"        "$base/$asset"
+curl -fsSL -o "$tmp/$asset.sha256" "$base/$asset.sha256"
+( cd $tmp && sha256sum -c "$asset.sha256" )      # or shasum -a 256 on darwin
+command -v cosign >/dev/null && cosign verify-blob --certificate "$asset.pem" --signature "$asset.sig" \
+   --certificate-identity-regexp 'https://github.com/NiklasJavier/SOT/.+' \
+   --certificate-oidc-issuer https://token.actions.githubusercontent.com "$asset"
+if [ -w /usr/local/bin ] || command -v sudo >/dev/null; then dest=/usr/local/bin; else dest=$HOME/.local/bin; mkdir -p $dest; fi
+${SUDO} install -m755 "$tmp/$asset" "$dest/sot"
+```
+
+### 2.14 The owner one-liner (system-wide vs per-user)
+```bash
+curl -fsSL https://raw.githubusercontent.com/NiklasJavier/SOT/<ref>/install.sh | sudo bash   # -> /usr/local/bin/sot
+curl -fsSL https://raw.githubusercontent.com/NiklasJavier/SOT/<ref>/install.sh | bash        # -> ~/.local/bin/sot
+```
+
+> No standalone `justfile` code block appears in the schemas; the full recipe set is enumerated verbatim in §3(b).
+
+---
+
+## 3. Full Command & Recipe Surface
+
+### (a) `sot app …` CLI commands
+- `sot app` — bare: interactive App-Selektor on a TTY, `list` when piped (never blocks).
+- `sot app browse` / `sot app select` — force the interactive numbered selector.
+- `sot app list [--json] [--outdated] [--role runner]` (alias `ls`) — catalog∪installed overview with AppStatus.
+- `sot app search <query|term>` — fuzzy-filter the catalog non-interactively (all sources).
+- `sot app info <name|id> [--json]` — full manifest, source type, installed/available versions, dependency tree.
+- `sot app install <name|id>[@version]…` (aliases `add`, `i`) `[--yes] [--dry-run]` — topo-resolve `requires.apps`, dispatch InstallStrategy, record state.
+- `sot app update <name|id>|--all` (alias `up`) `[--yes]` — update to latest satisfying constraint, skips pinned.
+- `sot app upgrade --all` — apply every non-pinned outdated app.
+- `sot app outdated [--json] [--cached]` (alias `stale`) — the monitoring surface: apps with UPDATE_AVAILABLE (network unless `--cached` reads `last-check.json`).
+- `sot app status [<app>]` — dashboard/table: counts of up-to-date / outdated / pinned / unknown / broken (reads cached report by default).
+- `sot app check [--quiet] [--notify] [--refresh]` — the scheduled/refresh entrypoint; refreshes cache, writes `last-check.json`, notifies on change.
+- `sot app remove <name|id>` (aliases `rm`, `uninstall`) `[--yes]` — strategy.remove + SafeFsRemover + store delete.
+- `sot app pin <name|id>[@version|range] [--version <v>]` / `sot app unpin <name|id>` — freeze/unfreeze from updates.
+- `sot app refresh` (alias `sync`) — re-pull the catalog index from the configured remote. *(overlaps with `sot app catalog refresh` below — see §4)*
+- `sot app catalog list | add <url> | remove <id> | refresh` — manage runtime catalog sources + bust cache.
+- `sot ex …` — retained alias filtering `role=runner` (AAT/TID) over the same AppService.
+- `sot extensions …` / `sot plugins …` — deprecated aliases forwarding to `app list`/`app install` with a one-line deprecation notice.
+- Inherited automation flags (on `AppCommand`, scope=INHERIT): `--json`, `--yes/-y`, `--no-color`, `--catalog <url>`, `--dry-run`.
+
+### (b) justfile recipes
+- `just setup` — gradle wrapper bootstrap + addExtension (first-time contributors).
+- `just dev` → `./gradlew quarkusDev` — live-reload dev inner loop.
+- `just build` → `./gradlew build` — JVM jar + unit tests.
+- `just native` → `./gradlew build -Dquarkus.native.enabled=true` — mostly-static glibc native binary.
+- `just test` → `./gradlew check` — test + quarkusIntTest + JaCoCo.
+- `just lint` → `./gradlew spotlessCheck && shellcheck install.sh`.
+- `just fmt` → `./gradlew spotlessApply` — auto-format Java.
+- `just run *ARGS` → `./gradlew quarkusRun --quarkus-args='{{ARGS}}'` — run the CLI on the JVM.
+- `just install-local` → build native then `install -m755 build/sot ~/.local/bin/sot` — local dogfooding.
+- `just release TAG` → `git tag {{TAG}} && git push origin {{TAG}}` — triggers release.yml.
+- `just clean` → `./gradlew clean`.
+- `just apps` → wrapper for `sot app list`.
+- `just install <id>` → wrapper for `sot app install <id>`.
+- `just check` — wraps native `sot app check --refresh` for local runs.
+- `just install-timer` — installs the systemd timer/service (or cron) running `sot app check --quiet --notify` (delegated to `sot bootstrap`).
+- `just run-selector` — dev-loop: `./gradlew quarkusDev --quarkus-args='app'` to drive the selector on the JVM.
+- `just app-outdated` — CI helper wrapping `sot app outdated --json` for update-monitoring pipelines.
+
+### (c) gradle / install commands
+- `quarkus create cli de.jklein.sot:sot --gradle -x picocli` — scaffold the Gradle project (replaces `mvn create`).
+- `./gradlew addExtension --extensions='quarkus-jackson,quarkus-hibernate-validator,quarkus-qute'` — add remaining extensions.
+- `./gradlew quarkusDev` — live-reload dev.
+- `./gradlew build` — JVM jar + unit tests.
+- `./gradlew build -Dquarkus.native.enabled=true` — native binary in `build/`.
+- `./gradlew check` — Surefire/Failsafe equivalents (test + quarkusIntTest) + JaCoCo (CI gate).
+- `./gradlew spotlessCheck` / `./gradlew spotlessApply` — google-java-format check/apply.
+- `./gradlew quarkusRun --quarkus-args='…'` — run the CLI on the JVM.
+- `./gradlew jreleaserFullRelease` — aggregate collected native binaries → checksums + Syft SBOM + cosign + GitHub Release.
+- `./gradlew clean`.
+- `curl -fsSL https://raw.githubusercontent.com/NiklasJavier/SOT/<ref>/install.sh | sudo bash` — end-user system-wide install to `/usr/local/bin/sot`.
+- `curl -fsSL …/install.sh | bash` — per-user install to `~/.local/bin/sot`.
+- `SOT_VERSION=vX.Y.Z curl … | bash` (or first positional arg) — pin a version for reproducible installs (bypasses GitHub API).
+- `sot self-update` — in-binary update reusing the same asset/verify contract.
+
+---
+
+## 4. Consolidated Decisions
+
+| # | Question | Recommendation |
+|---|----------|----------------|
+| D1 | **Linux native linking (musl-static vs mostly-static glibc)** — the D1/Risk-1 contradiction | **Mostly-static glibc** (`-H:+StaticExecutableWithDynamicLibC`), NOT `--static --libc=musl`. The tool fork/execs ansible/git/docker; musl-static cannot. Default glibc runners; prove subprocess exec in native smoke before any release. |
+| D2 | Polymorphic `source:` block across strategies in a closed-world native binary | Keep `SourceSpec` generic (`AppSourceType` + raw `JsonNode options`); each strategy binds+validates its own typed slice in `resolve()`. Avoid Jackson `@JsonTypeInfo`/`@JsonSubTypes` (forces every subtype into reflection config). |
+| D3 | Does the old extension/CapabilityProvider layer survive as a separate subsystem? | **No — collapse it.** extension = an App with a `runner:` block. LocalDirectoryProvider→bundled CatalogSource, RemoteGitProvider→git CatalogSource + git-repo strategy, CapabilityService→AppService, CapabilityStateStore→InstalledAppStore. Keep old vocabulary only as aliases. |
+| D4 | Bring a semver library or hand-roll comparison? | **Hand-roll** a native-safe `Version`/`VersionConstraint`/`SemVer` (semver precedence, v-prefix, prerelease ordering, ranges); `org.semver4j` (pure-Java) an acceptable fallback if range grammar grows. *(Both areas agree.)* |
+| D5 | Where does the INSTALLED version come from? | A read-only `InstalledApps` port owned by the install/catalog layer (appId, version, digest, pin). Update-monitoring only reads, never writes install state — outdated is a pure function of catalog + installed state. |
+| D6 | How is the periodic check scheduled (binary is not a daemon)? | Bootstrap installs a **systemd timer** (primary) invoking `sot app check --quiet --notify`, cron fallback; the binary runs once per tick and exits. No in-process scheduler/daemon. |
+| D7 | Pin semantics? | EXACT pin = frozen → status PINNED (excluded from apply); RANGE pin = constraint-bounded → UPDATE_AVAILABLE only for a newer satisfying version. Pins stored in **user state** (`installed.yml`), not the catalog-owned manifest. |
+| D8 | Apps with non-semver tags (calver, git sha, docker `:latest`)? | Resolvers return a digest/opaque raw string; compare by **equality** (changed vs same), never a fabricated ordering. Optional manifest `tagPattern` regex extracts a semver where one exists; else report UNKNOWN. |
+| D9 | How is "latest available version" resolved without bloating strategies? | A `VersionSpec.strategy` separate from `source.type` (git-tag/github-release/compose-image-tag/apt-policy/static/script), resolved by `queryLatest()`; compare via compiled SemVer honouring `version.constraint` + pin. |
+| D10 | GitHub/registry rate limits and auth? | ETag conditional GETs + TTL cache + serve-stale on 429/remaining==0; optional PAT from config/env raises the ceiling. Docker uses anonymous bearer-token flow, upgradeable to configured creds. |
+| D11 | Catalog/manifest supply-chain trust (a manifest can invoke the script strategy)? | `CatalogSource` carries `CatalogTrust` (pinned git ref, or sha256/cosign for http-index); the **script strategy requires an interactive confirm** unless the catalog is signed+trusted. Owner's own catalog is the sole default trusted source. |
+| D12 | `apiVersion` / manifest & config schema evolution? | Carry `apiVersion: sot.dev/v1` from day one; unknown newer fields **warn-not-fail** within a compat window. One migration policy covers both manifests and config. |
+| D13 | Full-screen raw-mode TUI (JLine/lanterna) vs line-oriented selector? | **Line-oriented selector** (numbered list + BufferedReader loop + ANSI via ConsoleService). No JLine/lanterna/stty — the only trivially GraalVM-native-safe option that still gives multi-select + fuzzy filter. |
+| D14 | What happens when `sot app` is run bare? | On a TTY launch the selector; when not a TTY (`System.console()==null`, piped, CI) fall back to `list`(`--json`) and never block. Interactive verbs requiring input must fail loud with a hint to pass explicit flags. |
+| D15 | Is the interactive selector its own subcommand or the parent default? | **Both**: `AppCommand`'s bare Callable launches it (best UX), and an explicit `sot app browse|select` exists so scripts/help/tests can target it deterministically. |
+| D16 | How are app names completed given the catalog is runtime data (closed-world)? | picocli `completionCandidates=AppNameCandidates` reading the local catalog cache at runtime; `@RegisterForReflection`. Names cannot be baked at build time. |
+| D17 | Groovy vs Kotlin DSL for build.gradle? | **Groovy DSL** — what `quarkus create cli --gradle` emits by default, minimal single build file, no other Kotlin in the project. |
+| D18 | Run JReleaser as a Gradle plugin or standalone CLI in CI? | **Gradle plugin** (`org.jreleaser`) via `./gradlew jreleaserFullRelease` in one aggregating release job after the matrix uploads each binary — keeps versioning in gradle.properties. |
+| D19 | Should install.sh apt-install ansible/docker on Debian? | **No.** install.sh installs only the `sot` binary (assumes curl/ca-certificates). Runtime tools (git/ansible/docker) are detected/reported by `sot doctor`/`sot bootstrap`, never silently apt-installed by a piped-to-bash script. |
+| D20 | How does the one-liner pin a version? | Default to GitHub API `releases/latest`; allow `SOT_VERSION=vX.Y.Z` env or first positional arg for pinned installs; the `<ref>` in the raw URL only selects which install.sh runs, decoupled from which binary it fetches. |
+| D21 | cosign verification: keyless vs key-pair? | **Keyless** (Fulcio/Rekor, GitHub OIDC) — no long-lived key; install.sh verifies `certificate-identity-regexp` against the repo + the GitHub Actions OIDC issuer, treats cosign as best-effort (sha256 mandatory, cosign skipped-with-warning if absent). |
+| D22 | macOS release scope for the install path? | v1: ship linux amd64/arm64 as the mandated target; keep macOS JVM/dev only. install.sh detects darwin and prints a "build from source / JVM" message rather than 404ing. |
+
+**Flagged disagreements / overlaps to reconcile before writing the plan:**
+- **⚠️ Two designs for "resolve latest version":** app-model-and-catalog folds version-checking into `InstallStrategy.queryLatest()` (the same 5 install-strategy beans), while update-monitoring designs a **separate** `VersionResolver` SPI (5 resolver beans in `de.jklein.sot.app.update`). Same responsibility, two abstractions — pick one, or define the relationship (e.g. InstallStrategy delegates to VersionResolver).
+- **⚠️ Strategy-enum drift:** app-model `VersionSpec.strategy` = {git-tag, github-release, compose-image-tag, apt-policy, static, script} vs update-monitoring `UpdateStrategy` = {GITHUB_RELEASE, GIT_TAG, DOCKER_IMAGE, APT, SCRIPT}. Overlapping but not identical (compose-image-tag / apt-policy / static vs DOCKER_IMAGE / APT) — unify the vocabulary.
+- **⚠️ Two `AppService` interface shapes:** app-model's (`list(EnumSet<AppStatus>)`, `install(id, Optional<version>)`, `upgradeAll()`) vs app-selector's (`catalog()`/`installed()`/`outdated()`, `install(name, InstallOptions)`, `refresh()`). Reconcile into one contract.
+- **⚠️ Old-vocabulary alias semantics:** app-model keeps `sot ex` as a **live** `role=runner` filter alias; app-selector keeps `extensions`/`plugins` as **deprecated** forwarders. Decide whether legacy names are functional filters or deprecation shims.
+- **Minor:** catalog refresh has two spellings — `sot app refresh`/`sync` (app-selector) vs `sot app catalog refresh` (app-model). Pick one canonical command.
+
+---
+
+## 5. Native-Image Considerations & Risks
+
+### 5a. Native-image considerations (deduplicated union)
+1. **Closed-world fit (core pattern):** the fixed strategy/resolver SET is compiled in via `@All List<InstallStrategy>` / `@All List<VersionResolver>` → `Map<enum,bean>` at BUILD time; WHICH apps exist stays pure runtime data (git/http manifests). No `Class.forName`, no runtime classloading — this is exactly how "deeply dynamic without recompiling" is achieved.
+2. **Central `@RegisterForReflection`** in `runtime.ReflectionConfig` for every Jackson-mapped record: AppManifest, SourceSpec, VersionSpec, Requires, InstallSpec, RunnerSpec, CatalogIndex, InstalledApp, per-strategy option records, GitHub-release DTOs, Docker registry manifest/token DTOs, VersionCache/report records — or they bind empty/null.
+3. **Prefer per-strategy `JsonNode` binding** over Jackson base-type `@JsonSubTypes` to keep the polymorphic-deserialisation reflection surface small and predictable.
+4. **Bundled catalog** ships under `src/main/resources/apps/**/app.yml`, embedded via `quarkus.native.resources.includes` + materialised through `AssetExtractor` + `assets/manifest.txt` (native can't `Files.walk` the classpath). `assets/manifest.txt` is generated during the Gradle build (`processResources`/custom task).
+5. **TLS:** `quarkus.ssl.native=true` + embedded CA truststore covering api.github.com, ghcr.io, registry-1.docker.io, Debian mirrors (shared with self-update); http-index checksum/cosign verification uses `MessageDigest` (SUN provider, default-registered).
+6. **All strategies/resolvers shell out via shared `ProcessRunner`** → reinforces the mostly-static-glibc (NOT musl) constraint; musl-static would break all install/update/version-check. `ToolPreflight`/`sot doctor` confirms git/apt/docker/skopeo presence, degrades to UNKNOWN when absent.
+7. **No in-binary daemon/cron:** scheduling is external systemd/cron unit files materialised by bootstrap; native invoked per tick (fast start is the whole point).
+8. **No JLine/lanterna/ncurses/`stty`:** selector is plain ANSI writes + line reads — zero terminal reflection surface. `System.console()==null` under a pipe → selector must refuse (drives bare-`app`→`list` fallback).
+9. `AppNameCandidates` + any picocli help/version providers need `@RegisterForReflection` (reflectively instantiated by picocli).
+10. `--json` paths use the one shared build-time `YAMLMapper`/`ObjectMapper`.
+11. `add-all-charsets=true` / UTF-8 so glyphs + non-ASCII app summaries and release/tag names render in the binary.
+12. Version parsing is hand-rolled / reflection-free; inject a `Clock` (not System-time) for deterministic native + test behaviour. `SemVer` compare is pure Java, zero registration.
+13. Catalog cache dir, `installed.yml`, and install paths are runtime-writable dirs resolved from `SotPaths` at invocation — never captured at build time.
+14. Native build runs container-build via the pinned Mandrel builder image (`quarkus.native.container-build=true`) so CI runners need no local GraalVM; pin the exact builder-image tag to avoid Mandrel drift.
+15. JReleaser must declare NATIVE_IMAGE/BINARY distributions (no JRE bundled); install.sh must match the single-sourced `sot-<os>-<arch>` asset-naming contract.
+16. `quarkus.native.resources.includes` + `add-all-charsets` are build-behavior config → belong in `application.properties`, carried over verbatim from the Maven setup.
+
+### 5b. Top risks, ranked (risk → mitigation)
+1. **musl-static breaks fork/exec (the D1 contradiction)** — a portability-driven musl-static binary silently breaks every ansible/git/docker/apt shell-out, shipping a tool that cannot run. → Force `-H:+StaticExecutableWithDynamicLibC` (glibc); mandatory native smoke job execs a real subprocess (`git --version`) from the built binary and **gates release** (`fail-fast:false` per arch).
+2. **Supply-chain / arbitrary code execution** — an untrusted catalog manifest selecting the `script` (or apt-deb) strategy runs arbitrary code on install; `curl|bash` is a tampering/MITM surface. → Sign/pin catalog sources (git ref or cosign/sha256 on http-index); script strategy needs interactive confirm unless signed+trusted; install.sh does mandatory sha256 **and** cosign keyless verify (cert-identity pinned to repo + GitHub OIDC issuer), https only.
+3. **Native reflection miss binds silently to null → mis-install** — a per-strategy option record or DTO missing from ReflectionConfig deserialises to null and mis-installs. → Central ReflectionConfig lists every manifest+option+DTO record; a native integration test parses one manifest of each `source.type` and asserts full binding (release gate).
+4. **`outdated()`/`checkAll()` fan-out is slow / rate-limited** — N network calls (git ls-remote, Releases API 60/hr unauth, registry, apt) exhaust limits and drag. → Virtual-thread fan-out + per-app ETag conditional GETs (304 = free) + TTL cache keyed on `lastCheckedAt` + serve-stale on remaining==0 + optional PAT + denormalised latest version in CatalogIndex for a cheap first pass.
+5. **Version heterogeneity → false ordering** — many apps ship non-semver tags (calver/date/sha/`:latest`), yielding a fabricated up/down ordering. → Equality/digest comparison (changed-vs-same) when semver parse fails; optional manifest `tagPattern`; report UNKNOWN rather than guess a direction.
+6. **Selector blocks/hangs non-interactively** (CI, piped stdin, `curl | sot`) hanging automation. → Detect `System.console()==null`/non-TTY → fall back to `list`; every mutating verb has a non-interactive `--yes` form so nothing needs the selector.
+
+Further ranked risks (lower):
+7. **install.sh asset-naming/verification drifts** from what Gradle/JReleaser publishes → 404s or false verify failures. → Single-source the `sot-<os>-<arch>` schema referenced by both jreleaser config and install.sh; a release-smoke job runs the published one-liner against the fresh Release in a clean Debian container.
+8. **Scheduled check spams notifications** every tick. → Notify only on state-change (diff vs `last-check` report); debounce/summarise; `--quiet` default for the timer.
+9. **Docker/ghcr auth token dance + mutable tags** cause wrong "up-to-date". → Anonymous bearer-token flow with configurable creds; compare manifest DIGEST not tag string for `:latest`.
+10. **`sudo bash` fails / `/usr/local/bin` not writable** leaving no `sot` on PATH. → install.sh falls back to `~/.local/bin`, creates it, installs there, prints a PATH-export hint; honours existing SUDO/root; exits non-zero with a clear message.
+11. **Network flakiness / offline** aborts or misleads the whole report. → Per-app failure isolation → UpdateStatus.UNKNOWN with error text; aggregate always completes; `--cached`/`status` serve `last-check.json` offline.
+12. **Prerelease/draft GitHub releases** surface as latest → spurious updates. → Filter draft+prerelease by default; `includePrerelease` is an explicit per-app manifest opt-in.
+13. **Manifest expressiveness gap → strategy explosion** breaking closed-world simplicity. → Keep the `script` strategy as a typed escape hatch (install/update/remove/version hooks); only promote to a first-class strategy when a pattern recurs.
+14. **Dependency cycles among `requires.apps`** deadlock topo install order. → Kahn/DFS topo-sort with explicit cycle detection, failing loud with the offending chain before any strategy runs.
+15. **Legacy `module.yml` mismatch** — doesn't match AppManifest; the docker module bundles 3 compose apps as one entry. → Migration explodes each docker template into its own `docker-compose` app.yml, maps ansible/sdkman modules to runner/dependency apps; warn-not-fail apiVersion window.
+16. **Multi-arch native builds slow/flaky + Mandrel/Gradle drift** → non-reproducible binaries. → PRs run only JVM `check` + one linux-amd64 native smoke; full arm64+amd64 matrix only on tag; pin wrapper + quarkus platform + Mandrel builder-image; Renovate bumps must pass the native gate.
+17. **GitHub API rate-limit on unauthenticated `releases/latest`** breaks unattended installs. → `SOT_VERSION` pin (arg/env) bypasses the API and hits the deterministic `/releases/download/<tag>/` URL.
+18. **Raw-mode TUI temptation** pulls JLine/lanterna (native reflection + SSH/pipe breakage). → Commit to line-oriented; gate any future arrow-key nav behind an opt-in, separately native-verified module.
+19. **Deprecated `extensions`/`plugins` aliases drift/duplicate logic.** → Implement as forwarders that construct+invoke the corresponding `app` subcommand; cover in `@QuarkusMainTest`.
+20. **Dynamic completion reads stale/missing catalog cache.** → `AppNameCandidates` returns empty (not error) when absent; `sot app refresh` primes the cache; completion failure never aborts the command.
+21. **Long install/update runs look frozen in the selector.** → Stream every step through `ProgressReporter`/`ProgressSink` (Tee to log) with per-app progress lines.
+22. **Partial Maven→Gradle migration** leaves stale `mvnw`/`pom.xml`/`--libc=musl` references. → Delete pom.xml/mvnw/.mvn and grep the repo (README, workflows, pre-commit, docs) for `mvnw`/`mvn `/`pom.xml`/`--libc=musl` as a release-phase checklist.

--- a/docs/java-quarkus-design-brief.md
+++ b/docs/java-quarkus-design-brief.md
@@ -1,0 +1,376 @@
+# SOT Rewrite — Consolidated Design Brief (Bash → Java 21 / Quarkus / GraalVM native)
+
+Synthesised from the 9 layer-design agents. Canonical root package: **`de.jklein.sot`** (from the build foundation, matching Maven groupId `de.jklein.sot`). Sibling layers proposed divergent roots (`de.sot`, `dev.sot`, `com.sot`, `io.sot`) — all normalised to `de.jklein.sot.*` below; the naming conflict is logged in §7. Single-module Maven build, Java 21, Quarkus 3.37+, Mandrel/GraalVM native. External tools (ansible, ansible-vault, terraform, git, docker) are kept and shelled out via `ProcessBuilder`; Ansible playbooks/roles are embedded as classpath resources.
+
+---
+
+## 1. Per-Layer Design
+
+### 1.1 project-build-foundation  (effort: L)
+Single-module Maven project (`de.jklein.sot:sot`, Java 21) bootstrapped via `quarkus-maven-plugin:3.37.0:create -Dextensions='picocli,quarkus-jackson'`. Foundation owns the cross-cutting skeleton in `de.jklein.sot.runtime` + build files; siblings fill `cli/config/extension/vault/bootstrap/runner/process/doctor`. Provides the ONE shared `YamlMapperProducer` (@Produces YAMLMapper, kills R1's 4 parsers), `SotPaths` (one canonical layout from `$SOT_HOME`, default `/opt/SOT`, kills R4), `AssetExtractor` (classpath `ansible/**`,`docker/**`,`templates/**` → writable runtime dir), and `ReflectionConfig`. `application.properties` pins `quarkus.native.resources.includes`, `add-all-charsets=true`, Mandrel builder image. JVM profile = dev inner loop; `native` profile (`-Dnative`) via container-build. GitHub Actions release matrix (linux amd64/arm64, macos arm64) + thin `install.sh` (only remaining shell). Assets move under `src/main/resources/`.
+- pom.xml — config — single-module Maven build, quarkus-bom 3.37+, native profile via -Dnative
+- src/main/resources/application.properties — config — native resource includes, add-all-charsets, Mandrel image, banner off
+- de.jklein.sot.cli.SotCli — @Command — @TopCommand root shell (quarkus-picocli auto-provides @QuarkusMain); one entrypoint replacing bin/sot
+- runtime.YamlMapperProducer — CDI-bean — @Produces the single shared Jackson YAMLMapper
+- runtime.SotPaths — CDI-bean — resolves one canonical install/asset/config layout from $SOT_HOME
+- runtime.AssetExtractor — CDI-bean — copies embedded assets to writable dir so native shell-outs can exec them
+- runtime.ReflectionConfig — config — @RegisterForReflection over all config records + @RegisterResources
+- .github/workflows/release.yml — config — native build matrix producing per-platform binaries
+- install.sh — resource — platform detect + download prebuilt binary + symlink (the only shell)
+- mvnw / .mvn/wrapper — config — pinned Maven wrapper for reproducible builds
+
+### 1.2 cli-command-layer  (effort: L)
+Package `de.jklein.sot.cli`. One root `@TopCommand SotCommand implements Callable<Integer>` declaring the whole subcommand tree `{Bootstrap, Doctor, Vault, Runner, Extensions, Plugins, Update, Delete, Interactive, Help, AutoComplete.GenerateCompletion}`. Every command is a CDI bean (quarkus-picocli); state arrives by **constructor injection** of typed services (SotConfig, SotPaths, ExtensionService, VaultService, ProcessRunner, ConsoleService) — never positional argv, which structurally dissolves R3 (no `CLI_METADATA_ARGS`). Global options live once on root with `scope=INHERIT` (`--config/--profile/-v/--no-color`). Dispatch is exactly one path: `CommandLine.execute(args)` in `@QuarkusMain Main`. Aliases use native picocli `@Command(aliases=…)`; a dangling alias is uncompilable. Help/version/completion all derived from live `CommandSpec` (no printf drift). Interactive mode re-renders the same CommandSpec tree.
+- SotCommand — @Command — root; declares subcommand tree + inherited globals + version/help mixin
+- Main — class — @QuarkusMain; AliasExpander pre-parse, exception+exit-code handlers, the single dispatch
+- BootstrapCommand / DoctorCommand / VaultCommand / RunnerCommand / ExtensionsCommand / PluginsCommand / UpdateCommand / DeleteCommand / InteractiveCommand — @Command — verb subcommands injecting typed services
+- SotVersionProvider — class — IVersionProvider reading build-time version + git commit
+- AliasExpander — CDI-bean — typed Map<String,List<String>> for combo aliases (@f→doctor --fix), expanded pre-parse
+- AliasCheatSheetRenderer — class — IHelpSectionRenderer generating alias footer from live spec
+- ConsoleService / ProgressReporter — interface — ANSI/color + progress abstraction (TTY/--no-color aware)
+- SotExitCode — enum — typed exit codes (OK/USAGE/NOT_FOUND/RUNTIME) via setExitCodeExceptionMapper
+
+### 1.3 config-model  (effort: L)
+Package `de.jklein.sot.config`. ONE canonical nested-v2 schema as immutable records rooted at `SotConfig(system, ssh, logging, paths, tools, ansible, vault, runner, Map<String,ExtensionConfig> extensions)`. AAT/TID are no longer hardcoded fields — just entries in `extensions`, each a uniform `ExtensionConfig(enabled, repoUrl, dir, branch, inventoryPath, inventoryVars)`. Parsing happens once in `YamlConfigCodec`: read each source to `JsonNode`, `ConfigMerger` deep-merges override trees onto the default template, then `treeToValue`→`SotConfig` once. SnakeYAML tokenisation makes `#`-in-quotes/apostrophe/backslash corruption impossible; fixed record fields stop a stray `PATH:`/`IFS:` key clobbering shell vars. `PlaceholderResolver` resolves `__GENERATE_*__` sentinels topologically via a `GeneratedValue` enum; `ConfigValidator` runs Hibernate Validator + a hard gate rejecting any surviving placeholder. Vault master secret is NOT a field — `VaultConfig` holds only a `Path secretRef`; `SecretStore` keeps it in a 0600 root-owned file, so Jackson can never serialise it.
+- SotConfig — record — root aggregate; single canonical schema + Map<String,ExtensionConfig>
+- SystemConfig/SshConfig/LoggingConfig/PathsConfig/ToolsConfig/AnsibleConfig/RunnerConfig — record — typed sections with Bean-Validation constraints
+- VaultConfig — record — vault settings WITHOUT plaintext secret (file, content, mail, Path secretRef)
+- ExtensionConfig — record — uniform per-extension shape shared by aat/tid/custom
+- GeneratedValue — enum — every __GENERATE_*__ sentinel with dependency-ordered derivation lambda
+- HostContext — record — host facts (hostname, SecureRandom, install root) for derivation
+- YamlConfigCodec — CDI-bean — single YAML read/bind/serialize path
+- ConfigMerger — CDI-bean — deep JsonNode merge of default template + overrides before one bind
+- PlaceholderResolver — CDI-bean — resolves surviving placeholders topologically → new immutable record
+- ConfigValidator — CDI-bean — Hibernate-Validator + hard gate on leftover placeholders
+- SecretStore — CDI-bean — reads/writes vault master secret to a 0600 root-owned file
+- ConfigService — CDI-bean — single load/get/set/save facade (replaces sed/config_writer/save_plugin_state)
+- YamlMapperProducer — CDI-bean — @Produces build-time YAMLMapper (record module tuned)
+- default_config.yml — resource — the ONE canonical nested template on classpath
+
+### 1.4 extension-capability-layer  (effort: L)
+Package proposed `dev.sot.capability` → normalised `de.jklein.sot.extension`. Collapses module/plugin/extension/integration into ONE **Capability** concept sourced by pluggable `CapabilityProvider` CDI strategies (`origin()`, `discover()`, `materialize/remove/sync()`, `mutable()`). Two beans: `LocalDirectoryProvider` (@Identifier("local"), NIO-walks `$SOT_HOME/modules/*/module.yml`, immutable) and `RemoteGitProvider` (@Identifier("remote-git"), typed `RemoteCapabilityDef` for AAT/TID, git clone/pull) — R2's split dissolves structurally. `CapabilityRegistry` injects `@All List<CapabilityProvider>` (build-time CDI) into one `Map<String,Capability>`. `CapabilityService` is the SINGLE lifecycle owner (list/info/install/remove/enable/disable/sync/run). `ExtensionManifest` is a typed `@RegisterForReflection` record (name, version, `CapabilityType`{TOOL,SERVICE,RUNNER}, Requirements, deps, apiVersion) parsed by one Jackson `ObjectMapper(YAMLFactory)`. State persists via `CapabilityStateStore` → `capabilities.yml`. Remote ops route through shared `GitService`; removal through `SafeFsRemover` (absolute+min-depth+denylist); runner assets invoked via ProcessBuilder argv (never chmod+x-then-exec). Deps resolved topologically before install.
+- CapabilityProvider — interface — SPI strategy over one backend (discover/materialize/remove/sync/mutable)
+- LocalDirectoryProvider — CDI-bean — @Identifier("local"); walks modules/*/module.yml
+- RemoteGitProvider — CDI-bean — @Identifier("remote-git"); typed RemoteCapabilityDef, clone/pull via GitService
+- CapabilityRegistry — CDI-bean — @All List<CapabilityProvider> → one Map<String,Capability>
+- CapabilityService — CDI-bean — single lifecycle owner (validation, dep resolution, state, view)
+- ExtensionManifest — record — typed model of module.yml (one schema, one parser)
+- Capability — record — runtime aggregate: manifest + origin + resolved path + enabled state + provider id
+- CapabilityType — enum — TOOL|SERVICE|RUNNER; old 'integration' → REMOTE_GIT origin
+- CapabilityStateStore — CDI-bean — typed round-trip persistence to capabilities.yml
+- ManifestParser — CDI-bean — wraps ObjectMapper(YAMLFactory); parse+validate at discovery
+- ExtensionsCommand — @Command — picocli parent (aliases ex) with subcommand beans
+- RemoteCapabilityDef — record — typed remote def (name/repoUrl/branch/dir/runner) from config
+
+### 1.5 process-orchestration-layer  (effort: M)
+Package proposed `com.sot.exec` → normalised `de.jklein.sot.process` (+ `runner/` for the typed invocation builders). One `@ApplicationScoped ProcessRunner` wraps `ProcessBuilder`, taking a typed `ProcessSpec` (executable, args, env, workingDir, StdinSource, timeout, failOnNonZero, interactive) → `ProcessResult(exitCode, elapsed, timedOut)`. Two virtual-thread drainers avoid pipe-buffer deadlock, emitting `OutputLine` to a `ProgressSink`; `TeeSink` fans to UI + append-only log (replaces `run_with_logging`/`tee`). Secrets NEVER touch argv: `SecretMaterializer` holds a `char[]` `Secret` and passes it via 0600 temp file / scrubbed env / stdin. Typed invocation records (`AnsiblePlaybookInvocation`, `AnsibleVaultInvocation`, `TerraformInvocation`, `DockerInvocation`) each build the arg list in ONE `toProcessSpec()`. `GitService.gitSync(GitSyncSpec(dir,url,branch,SyncMode))` with `PULL` vs `RESET_HARD` (--force-gated) collapses 4 git-sync sites (R6). `WorkspaceManager` extracts embedded assets to a 0700 hashed work dir; interactive tools use `inheritIO()`.
+- ProcessRunner — CDI-bean — ProcessBuilder facade; ProcessSpec→ProcessResult; concurrent draining, timeout, exit policy
+- ProcessSpec — record — immutable invocation descriptor
+- ProcessResult — record — exitCode, elapsed, timedOut, diagnostic tail
+- ProcessExecutionException — class — thrown on non-zero/timeout with redacted command line
+- ProgressSink — interface — seam to progress UI; TeeSink also appends to log file
+- Secret — class — char[]-backed AutoCloseable holder with clear(); never toString/log
+- SecretMaterializer — CDI-bean — passes secrets via 0600 temp file / env / stdin, never argv; shred in finally
+- GitService — CDI-bean — single gitSync(GitSyncSpec) + ensureTool preflight
+- GitSyncSpec — record — dir/url/branch/SyncMode{PULL,RESET_HARD}
+- AnsiblePlaybookInvocation / AnsibleVaultInvocation / TerraformInvocation / DockerInvocation — record — typed options → single toProcessSpec() arg builder
+- WorkspaceManager — CDI-bean — extracts embedded assets to 0700 hashed work dir (idempotent, content-hash)
+- ToolPreflight — CDI-bean — resolves+validates git/ansible/terraform/docker on PATH once
+
+### 1.6 bootstrap-installer-native-packaging  (effort: L)
+Package proposed `io.sot.bootstrap` → normalised `de.jklein.sot.bootstrap`. Two-tier install: a ~50-line `install.sh` (uname os/arch → download `sot-<os>-<arch>` + `.sha256` from pinned Release → verify → `install -m755` to `/usr/local/bin/sot`) and the in-binary `sot bootstrap` / `sot self-update`. Bootstrap runs a typed task pipeline: `BootstrapTask` interface (`id()`, `critical()`, `TaskResult run(ctx)`) implemented by CDI beans (Preflight, MaterializeAssets, DirectoryLayout, DependencyInstall, VaultReference, Finalize), injected `@All`; `TaskRunner` aggregates `TaskResult`s into a `BootstrapReport` whose footer + exit code reflect ACTUAL outcomes (kills the "always prints success" lie). One `InstallLayout` record derives every path from a single `rootDir` (default `/opt/sot`) — no self-clone, no CLI-file sed-patch. `sot self-update`: `GitHubReleaseClient` (JDK HttpClient) → `ChecksumVerifier` (SHA-256) → `BinaryUpdater` writes sibling temp, verifies, `Files.move(ATOMIC_MOVE)` over itself, re-execs (replaces update.sh's unguarded `git reset --hard`).
+- install.sh — resource — thin platform-detecting downloader (only remaining shell)
+- BootstrapCommand — @Command — sot bootstrap; typed options, builds ctx, runs TaskRunner, sets exit code
+- SelfUpdateCommand — @Command — sot self-update; GitHubReleaseClient→ChecksumVerifier→BinaryUpdater + confirm gate
+- BootstrapTask — interface — id()/critical()/TaskResult run(ctx)
+- TaskRunner — CDI-bean — @All List<BootstrapTask>, runs in order, aggregates BootstrapReport
+- TaskResult — record — id, Status(PASS/FAIL/SKIP), Duration, message, Optional<Throwable>
+- BootstrapReport — record — aggregate; computes overall success + exit code
+- InstallLayout — record — single-source path model from one rootDir
+- AssetExtractor — CDI-bean — materialises embedded assets driven by build-generated assets/manifest.txt
+- ProcessRunner — CDI-bean — single ProcessBuilder wrapper for all subprocess calls (shared w/ §1.5)
+- DependencyInstaller — interface — per-tool strategy (Sdkman/Docker/Ansible), CDI-discovered, extensible
+- GitHubReleaseClient — CDI-bean — JDK HttpClient querying Releases API for os/arch asset+checksum URLs
+- ChecksumVerifier — CDI-bean — SHA-256 MessageDigest verification
+- BinaryUpdater — CDI-bean — resolves real path, downloads temp, verifies, atomic-move, re-exec
+- BuildInfo — config — build-time-stamped version/commit for update comparison
+
+### 1.7 security-vault-layer  (effort: L)
+Package proposed `de.sot.security.vault` → normalised `de.jklein.sot.vault`. The secret NEVER becomes a `String`: it lives only in `Secret`, a final AutoCloseable over `char[]`/`byte[]` whose `close()` zero-fills and `toString()` returns `"****"` — no_log becomes a type property. `VaultPasswordSource` is a sealed interface — `Interactive` (`console.readPassword()`), `PasswordFile(Path)` (0600 root-owned, referenced by path in config), `EnvVar(SOT_VAULT_PASSWORD)`; `SecretResolver` picks highest-priority source and fails loud when none in non-interactive runs. Master secret never from argv/config.yaml. `TransientPasswordFile` materialises a Secret into a tmpfs dir (`XDG_RUNTIME_DIR`→`/dev/shm`, tmpfs-verified else fail) with mode-at-O_CREAT 0600 + SecureRandom name (kills epoch-name symlink race); `close()` overwrites+unlinks. `PosixGuards` centralises NOFOLLOW opens / 0700 dirs / root-ownership asserts. `AnsibleVaultRunner` wraps ProcessBuilder for encrypt/view/rekey (password via 0600 file or `/dev/stdin`, never argv); `edit` uses `Redirect.INHERIT`. `SecretGenerator` (SecureRandom) replaces Jinja `lookup('password')`; `VaultTemplateRenderer` uses a type-safe `@CheckedTemplate` Qute `secrets.yml`. `VaultService` owns init/view/edit/rekey/read — view+rekey now real.
+- Secret — class — final AutoCloseable char[]/byte[] carrier; zero-fills, masks toString; only in-memory secret carrier
+- VaultPasswordSource — interface — sealed source (Interactive/PasswordFile(0600)/EnvVar); never argv/config
+- SecretResolver — CDI-bean — resolves highest-priority source to a Secret; fails loud when none non-interactively
+- TransientPasswordFile — class — AutoCloseable tmpfs 0600 file, SecureRandom name, overwrite+unlink on close
+- PosixGuards — class — atomic 0600/0700 creation, NOFOLLOW opens, root-ownership + tmpfs assertions
+- AnsibleVaultRunner — CDI-bean — ProcessBuilder wrapper; password via file/stdin, inherits TTY for edit, never logs
+- SecretGenerator — CDI-bean — SecureRandom secret generation replacing Jinja lookup('password')
+- VaultTemplateRenderer — CDI-bean — renders type-safe Qute vault template into transient file
+- VaultSecrets — record — typed decrypted vault; fail-loud accessors, no weak defaults, never logged
+- VaultService — CDI-bean — facade owning init/view/edit/rekey/read lifecycle
+- VaultCommand — @Command — picocli parent (Init/View/Edit/Rekey) injecting VaultService
+- vault template (secrets.yml) — resource — @CheckedTemplate Qute asset, replaces vault_template.j2
+
+### 1.8 testing-strategy  (effort: L)
+Tests in `src/test/java/de/jklein/sot/...` mirroring production, + `src/test/resources` fixtures. THREE tiers. **Tier 1** fast JVM component tests (`@QuarkusTest`): real CDI wiring, the single external seam `ProcessRunner` (interface) is swapped — `@InjectMock` (quarkus-junit5-mockito) or `RecordingProcessRunner` (`@Alternative`, test-scope) capturing ordered `ProcessInvocation(argv,env,stdin,cwd)`; no ansible/git/docker ever runs. **Tier 2** CLI e2e via `@QuarkusMainTest` → `QuarkusMainLauncher.launch(args)` → `LaunchResult`, asserting the whole command tree / exit codes / help. **Tier 3** native smoke: same class subclassed `@QuarkusMainIntegrationTest` (failsafe, `-Dnative`) black-box; since Mockito can't inject, native tests use `FakeToolPathResource` (temp bin of thin fake tools on PATH). Signature tests: `ConfigRoundtripTest` (jqwik `load(save(cfg))==cfg` + golden-file) replaces 4 parsers; `VaultBehaviorTest` asserts no secret on argv, 0600 RAM file, gone-after; `ExtensionManagerTest`, `PathGuardTest`, `DoctorServiceTest`, `CompletionTest` close Bash gaps. AssertJ + JaCoCo per-package gate in CI; `%test` props point install-root/PATH at `@TempDir`.
+- ProcessRunner — interface — single mockable seam over ProcessBuilder
+- RecordingProcessRunner — CDI-bean — @Alternative test double recording ordered ProcessInvocation
+- CliMainTest — class — @QuarkusMainTest driving QuarkusMainLauncher.launch → LaunchResult
+- NativeSmokeIT — class — @QuarkusMainIntegrationTest against the built native binary
+- FakeToolPathResource — resource — @QuarkusTestResource prepending fake ansible/vault/git/docker to PATH
+- ConfigRoundtripTest — class — jqwik property roundtrip + golden-file over the one SotConfig record
+- VaultBehaviorTest — class — behavioural: no secret on argv, 0600 RAM file via PosixFilePermissions, gone after
+- ExtensionManagerTest — class — unified registry over LocalDir + GitRepo providers + enable/disable roundtrip
+- PathGuardTest — class — safe-delete denylist (/, /usr, empty, min-depth) + fail-closed guards
+- DoctorServiceTest — class — diagnostics over @InjectMock ProcessRunner (tool present/absent)
+- TestProcessProfile — config — %test props + QuarkusTestProfile pointing paths at @TempDir
+
+### 1.9 ci-cd-release  (effort: L)
+Four hand-rolled Bash-CI workflows collapse into 3 declarative Maven-owned workflows + JReleaser; the build tool (not a dir glob) defines what is compiled/tested/scanned, so drift is impossible. `ci.yml` (PR/push): `setup-graalvm@v1` (Mandrel/GraalVM 21 pinned) → `./mvnw -B verify` (Surefire + Failsafe @QuarkusTest, Spotless google-java-format, JaCoCo) → SonarCloud Quality Gate as a REQUIRED check (no continue-on-error) → shellcheck+shfmt on the ONE `install.sh` → one `linux-amd64` native smoke job (`SOT version`, config round-trip, `doctor --dry-run`, `generate-completion`). `native-build.yml` (reusable `workflow_call`): matrix over `ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-13`, `macos-14` (no QEMU); Linux uses `--static --libc=musl`. `release.yml` (tag `v*`): calls native-build, then `jreleaser-maven-plugin` assemble+release → per-platform `.tar.gz`/`.zip`, `checksums_sha256.txt`, Syft SBOM, cosign signatures on GitHub Releases; `install.sh` verifies checksum + cosign before extracting. Gates FAIL the build (no `|| true`), correctness proven by executing the binary.
+- .github/workflows/ci.yml — config — PR/push gate: mvnw verify, Spotless, JaCoCo, Sonar Quality Gate, install.sh lint, linux-amd64 native smoke
+- .github/workflows/native-build.yml — config — reusable matrix over 4 native runners, per-arch binary + smoke + artifact
+- .github/workflows/release.yml — config — tag v*: native-build → JReleaser assemble+release (binaries/checksums/SBOM/cosign)
+- jreleaser.yml — config — per-platform archive + checksum + Syft SBOM + cosign + GitHub Releases publisher
+- install.sh — resource — detect os/arch, download tarball, verify checksum+cosign, extract, symlink
+- .pre-commit-config.yaml — config — Spotless, shellcheck/shfmt scoped to install.sh, yamllint, ansible-lint, gitleaks
+- sonar-project + pom plugins — config — Spotless/JaCoCo/Sonar/JReleaser; build tool defines scanned set
+
+---
+
+## 2. Consolidated Package Tree
+
+```
+de.jklein.sot/                            root package (Maven groupId de.jklein.sot, artifactId sot)
+├── cli/                                  Picocli command tree — the single dispatch surface (§1.2)
+│   ├── SotCommand (SotCli)               @TopCommand root; declares subcommand tree + inherited globals
+│   ├── Main                              @QuarkusMain; AliasExpander pre-parse + CommandLine.execute
+│   ├── BootstrapCommand                  `sot bootstrap` → bootstrap.BootstrapService/TaskRunner
+│   ├── SelfUpdateCommand                 `sot self-update` → bootstrap.BinaryUpdater
+│   ├── DoctorCommand                     `sot doctor [--fix]` → doctor.DoctorService
+│   ├── VaultCommand (+Init/View/Edit/Rekey) `sot vault …` → vault.VaultService
+│   ├── RunnerCommand                     `sot runner <ext> <playbook>` → process/runner invocations
+│   ├── ExtensionsCommand (aliases ex)    list/install/remove/sync/run → extension.CapabilityService
+│   ├── PluginsCommand                    list/info/enable/disable → same CapabilityService
+│   ├── UpdateCommand / DeleteCommand     maintenance verbs (typed @Option flags)
+│   ├── InteractiveCommand                numbered menu built from live CommandSpec
+│   ├── SotVersionProvider                IVersionProvider (build-time version + git commit)
+│   ├── AliasExpander                     typed combo-alias map (@f→doctor --fix), pre-parse
+│   ├── AliasCheatSheetRenderer           IHelpSectionRenderer (alias footer from spec)
+│   ├── ConsoleService / ProgressReporter ANSI/color + progress abstraction (TTY/--no-color)
+│   └── SotExitCode                       typed exit codes via setExitCodeExceptionMapper
+├── config/                               ONE canonical typed config schema (§1.3)
+│   ├── SotConfig                         root record aggregate + Map<String,ExtensionConfig>
+│   ├── SystemConfig/SshConfig/LoggingConfig/PathsConfig/ToolsConfig/AnsibleConfig/RunnerConfig  typed sections
+│   ├── VaultConfig                       vault settings WITHOUT secret (Path secretRef only)
+│   ├── ExtensionConfig                   uniform per-extension shape (aat/tid/custom)
+│   ├── RemoteCapabilityDef               typed remote def (name/repoUrl/branch/dir/runner)  [extension-consumed]
+│   ├── GeneratedValue (enum)             __GENERATE_*__ sentinels + ordered derivation
+│   ├── HostContext                       host facts (hostname, SecureRandom, root) for derivation
+│   ├── YamlConfigCodec                   single YAML read/bind/serialize path
+│   ├── ConfigMerger                      deep JsonNode merge of default + overrides
+│   ├── PlaceholderResolver               resolves sentinels topologically → new record
+│   ├── ConfigValidator                   Hibernate-Validator + hard gate on leftover placeholders
+│   ├── SecretStore                       reads/writes vault master secret to 0600 root file
+│   └── ConfigService                     single load/get/set/save facade
+├── extension/                            unified Capability model (proposed pkg `capability`) (§1.4)
+│   ├── CapabilityProvider (interface)    SPI: discover/materialize/remove/sync/mutable
+│   ├── LocalDirectoryProvider            @Identifier("local"); walks modules/*/module.yml
+│   ├── RemoteGitProvider                 @Identifier("remote-git"); RemoteCapabilityDef → GitService
+│   ├── CapabilityRegistry                @All List<CapabilityProvider> → one Map<String,Capability>
+│   ├── CapabilityService                 single lifecycle owner (list/info/install/remove/enable/disable/sync/run)
+│   ├── ExtensionManifest                 typed model of module.yml (one schema)
+│   ├── Capability                        runtime aggregate (manifest+origin+path+state+provider)
+│   ├── CapabilityType (enum)             TOOL|SERVICE|RUNNER
+│   ├── CapabilityStateStore              typed round-trip persistence → capabilities.yml
+│   ├── ManifestParser                    ObjectMapper(YAMLFactory) parse+validate at discovery
+│   └── SafeFsRemover                     absolute+min-depth+denylist guarded removal
+├── vault/                                secret-safe ansible-vault layer (proposed pkg `security.vault`) (§1.7)
+│   ├── Secret                            final AutoCloseable char[]/byte[]; zero-fill + mask  [SHARED w/ process]
+│   ├── VaultPasswordSource (sealed)      Interactive / PasswordFile(0600) / EnvVar
+│   ├── SecretResolver                    highest-priority source → Secret; fail-loud
+│   ├── TransientPasswordFile             tmpfs 0600 file, SecureRandom name, overwrite+unlink
+│   ├── PosixGuards                       NOFOLLOW opens, 0600/0700, root-ownership + tmpfs asserts
+│   ├── AnsibleVaultRunner                ProcessBuilder for encrypt/view/rekey; edit via inheritIO
+│   ├── SecretGenerator                   SecureRandom generation (replaces Jinja lookup)
+│   ├── VaultTemplateRenderer             @CheckedTemplate Qute → transient file
+│   ├── VaultSecrets                      typed decrypted vault (fail-loud, never logged)
+│   └── VaultService                      facade owning init/view/edit/rekey/read
+├── process/                              ProcessBuilder exec engine (proposed pkg `exec`) (§1.5)
+│   ├── ProcessRunner (interface)         single mockable exec seam  [testing requires interface]
+│   ├── ProcessRunnerImpl                 @ApplicationScoped concurrent-draining implementation
+│   ├── ProcessSpec / ProcessResult       typed invocation descriptor + result
+│   ├── ProcessExecutionException         non-zero/timeout with redacted command line
+│   ├── ProgressSink (interface) / TeeSink UI seam + append-only log (replaces run_with_logging)
+│   ├── SecretMaterializer                secrets via 0600 file / env / stdin, never argv
+│   ├── GitService / GitSyncSpec          single gitSync(PULL|RESET_HARD) + ensureTool
+│   ├── WorkspaceManager                  extract embedded assets → 0700 hashed work dir
+│   └── ToolPreflight                     resolve+validate git/ansible/terraform/docker on PATH
+├── runner/                               typed external-tool invocation builders (§1.5 co-located; split per foundation tree)
+│   ├── AnsiblePlaybookInvocation         → single toProcessSpec()
+│   ├── AnsibleVaultInvocation            → wires --vault-password-file to SecretMaterializer
+│   ├── TerraformInvocation               → terraform -chdir/action/var-file
+│   └── DockerInvocation                  → docker arg builder
+├── bootstrap/                            in-binary bootstrap + self-update (proposed pkg `io.sot.bootstrap`) (§1.6)
+│   ├── BootstrapService / TaskRunner     @All List<BootstrapTask>, aggregates BootstrapReport
+│   ├── BootstrapTask (interface)         id()/critical()/TaskResult run(ctx)
+│   ├── PreflightTask / MaterializeAssetsTask / DirectoryLayoutTask / DependencyInstallTask / VaultReferenceTask / FinalizeTask  task beans
+│   ├── TaskResult / BootstrapReport      honest per-task + aggregate outcome (drives exit code)
+│   ├── InstallLayout                     single-source path model from one rootDir
+│   ├── DependencyInstaller (interface)   Sdkman/Docker/Ansible install strategies
+│   ├── GitHubReleaseClient               JDK HttpClient → Releases API
+│   ├── ChecksumVerifier                  SHA-256 MessageDigest
+│   ├── BinaryUpdater                     atomic self-replace + re-exec
+│   └── BuildInfo                         build-time version/commit stamp
+├── doctor/                               diagnostics (§1.2 DoctorCommand backing)
+│   └── DoctorService                     tool/config/path preflight findings (over ProcessRunner)
+└── runtime/                              cross-cutting foundation skeleton (§1.1)
+    ├── YamlMapperProducer                @Produces the ONE shared Jackson YAMLMapper
+    ├── SotPaths                          one canonical layout from $SOT_HOME
+    ├── AssetExtractor                    embedded assets → writable runtime dir (manifest-driven)
+    └── ReflectionConfig                  @RegisterForReflection(all records) + @RegisterResources
+
+src/main/resources/                       embedded assets + runtime config
+├── application.properties                native resource includes, add-all-charsets, Mandrel image, banner off
+├── config/default_config.yml             the ONE canonical nested config template
+├── templates/vault/secrets.yml           @CheckedTemplate Qute vault template
+├── ansible/**                            playbooks/roles/inventory (embedded, extracted at runtime)
+├── docker/**                             Dockerfiles/compose templates (embedded)
+├── modules/**/module.yml                 bundled capability manifests
+└── assets/manifest.txt                   build-generated list AssetExtractor iterates (native can't Files.walk)
+
+build & CI (repo root)
+├── pom.xml                               single-module Maven; quarkus-bom 3.37+, native profile, JReleaser/Spotless/JaCoCo/Sonar plugins
+├── mvnw / .mvn/wrapper                   pinned Maven wrapper
+├── install.sh                            THE ONLY remaining shell: detect os/arch, download+verify(checksum+cosign), install -m755
+├── jreleaser.yml                         per-platform archive + checksum + SBOM + cosign + Releases publisher
+├── .pre-commit-config.yaml               Spotless, shellcheck/shfmt(install.sh), yamllint, ansible-lint, gitleaks
+└── .github/workflows/{ci,native-build,release}.yml   Maven-owned gates + native matrix + tagged release
+```
+
+---
+
+## 3. Full Quarkus Extension / Dependency List
+
+### Runtime
+- **io.quarkus:quarkus-picocli** — CLI command tree, @QuarkusMain/PicocliRunner, AutoComplete.GenerateCompletion, @QuarkusMainTest infra
+- **io.quarkus:quarkus-arc** — CDI container; build-time `@All List<…>` bean wiring (providers, tasks) — no runtime scanning
+- **io.quarkus:quarkus-jackson** — JSON/YAML ObjectMapper + build-time ObjectMapperCustomizer
+- **com.fasterxml.jackson.dataformat:jackson-dataformat-yaml** — YAML backend (pulls SnakeYAML) for config, module.yml, decrypted vault YAML
+- **io.quarkus:quarkus-hibernate-validator** — Bean Validation on config records (@Min/@Max port, @Pattern names)
+- **io.quarkus:quarkus-qute** — type-safe @CheckedTemplate for the vault `secrets.yml` template (no runtime reflection)
+- (io.smallrye.common `@Identifier` for named providers ships with Arc — build-time processed)
+
+### Test
+- **io.quarkus:quarkus-junit5** — @QuarkusTest / @QuarkusMainTest / @QuarkusMainIntegrationTest
+- **io.quarkus:quarkus-junit5-mockito** — @InjectMock ProcessRunner
+- **io.quarkus:quarkus-jacoco** — per-package coverage gate
+- **org.assertj:assertj-core** — assertions
+- **net.jqwik:jqwik** — property-based config round-trip generators
+
+### Build / release plugins & actions (not Quarkus extensions)
+- **io.quarkus:quarkus-maven-plugin** — build + native packaging
+- **org.jreleaser:jreleaser-maven-plugin** — per-platform archives, checksums, SBOM, cosign, Releases
+- **com.diffplug.spotless:spotless-maven-plugin** — google-java-format
+- **org.jacoco:jacoco-maven-plugin** — coverage thresholds
+- **org.sonarsource.scanner.maven:sonar-maven-plugin** — SonarCloud Quality Gate
+- **graalvm/setup-graalvm@v1** (Mandrel/GraalVM CE 21, pinned) · **anchore/sbom-action** (Syft) · **sigstore/cosign**
+
+---
+
+## 4. Capability Mapping: Bash → Java
+
+Legend for the last column: **[S]** = dissolves *structurally* (the Java design makes the finding impossible by construction); **[C]** = still needs *deliberate design care* (a real risk survives and is only mitigated, not eliminated — see §5/§6).
+
+| Bash file / subsystem | Replacing Java component(s) | Root cause / theme dissolved |
+|---|---|---|
+| `bin/sot` (path bootstrap, CLI_METADATA_ARGS, dispatch case, resolve_command_path, run_interactive_mode) | `cli.Main` + `SotCommand` tree + constructor-injected services | **R3** positional argv contract; **Theme A** dual dispatch (81-82) — [S] |
+| `lib/cli/registry.sh` (register_command, categorized/detail help, interactive menu, completion gens) | `SotCommand` subcommand tree + `AliasCheatSheetRenderer` + `InteractiveCommand` | **Theme A/I** registry-vs-fs duality; help drift (84,124); empty-path plugin cmds (83) — [S] |
+| `lib/cli/aliases.sh` | picocli `@Command(aliases=…)` + `AliasExpander` | **Theme F** dead alias `s`→setup 127-exit (122); dead/multi-word aliases (134/135) — [S] |
+| `lib/cli/progress.sh`, `lib/core/colors.sh` + 6 copy-pasted ANSI blocks | `cli.ConsoleService` / `ProgressReporter` (one compiled binary) | **R6** duplicated color; **Theme E** — [S] |
+| `completions/*.{bash,zsh}` | picocli `AutoComplete.GenerateCompletion` (spec-derived) | **R7 / Theme I** completion triplication + drift (175) — [S] |
+| `lib/core/yaml_parser.sh`, `parse_plugin_yaml`, `config_defaults` inline regex, `config/default_config{,_v2}.yml` | `config.YamlConfigCodec` + `runtime.YamlMapperProducer` + one `default_config.yml` + `SotConfig` records | **R1** 4 parsers / schema split; **Theme D** flat-vs-nested; **Theme G** #-truncation, xargs corruption; **Theme H** PATH/IFS key injection — [S] |
+| `lib/core/bootstrap/config_defaults.sh` (generate_dynamic_defaults) | `config.PlaceholderResolver` + `GeneratedValue` + `ConfigValidator` gate | **Theme F** `__GENERATE_SCRIPTS_DIR__` leaks to disk (130) — [S] |
+| `lib/core/bootstrap/config_writer.sh`, `sed`, `save_plugin_state`, `config/overrides/` | `config.ConfigService.save` + `ConfigMerger` | **Theme D** 3 mutation paths + unimplemented overrides — [S] |
+| `lib/plugins/manager.sh` + `lib/extensions/manager.sh` + `commands/extensions.sh` (3 managers, 4 terms) | `extension.CapabilityRegistry` + `CapabilityService` + `CapabilityProvider` strategies | **R2 / Theme B** four terms, three disjoint subsystems (89-92) — [S] |
+| `modules/*/module.yml`, `parse_plugin_yaml` (4th parser), PLUGIN_DEPENDENCIES | `extension.ExtensionManifest` + `ManifestParser`; topological dep resolution | **Theme B** schema-vs-parser incoherence (89); ignored deps (90); type taxonomies (91) — [S] |
+| `_update_config_value` / `save_plugin_state` (never persists) | `extension.CapabilityStateStore` (typed round-trip) | **Theme B/F** persistence lie (126,132) — [S] |
+| `commands/vault.sh`, `modules/ansible/roles/{vault,read_vault_parameter}`, `bootstrap/vault_template.j2` | `vault.VaultService` + `AnsibleVaultRunner` + `Secret` + `TransientPasswordFile` + `VaultTemplateRenderer` + `VaultSecrets` | **R5 / Theme H** secret on argv (158), plaintext in config (157), persistent vault_pass.txt (159), debug dump no no_log (161), weak default creds (167), unimplemented view/rekey (129/210) — [S]; symlink race (165), tmpfs guarantee, secure-delete — [C] |
+| `config/load_config.yml` vault wiring + config-merge/derive | `config.SecretStore` (0600 secretRef) + `PlaceholderResolver` | **R5/Theme H** secret out of YAML — [S] |
+| `commands/runner.sh` (ansible-playbook/terraform, run_with_logging tee, sync_repo), `modules/ansible/commands/trigger.sh` | `process.ProcessRunner` + `runner.*Invocation` records + `TeeSink` + `ToolPreflight` | **R3/R6** positional argv + duplicated arg-build; scattered `command -v` — [S] |
+| `bootstrap/init.sh`/`tasks.sh` git clone, `lib/extensions/manager.sh` fetch+pull, `update.sh` fetch+reset --hard+clean | `process.GitService.gitSync(GitSyncSpec, SyncMode PULL/RESET_HARD)` | **R6** 4 divergent git-sync sites; **Theme G** unguarded destructive reset (145) — [S]; RESET_HARD data-loss — [C] |
+| `modules/docker/install.sh` mktemp extraction | `process.WorkspaceManager` / `runtime.AssetExtractor` (0700 hashed dir) | native asset extraction; TOCTOU-safe temp — [S] |
+| `bootstrap/init.sh` curl\|bash self-clone + re-exec + re-clone | `install.sh` (thin) + prebuilt native binary + `bootstrap.InstallLayout` | **R4** two roots (/opt/SOT vs /etc/DevOpsToolkit vs /opt/AAT), **Theme C** self-clone/CLI-edit/SETUP_DIR (95-99) — [S]; install-root default disagreement — [C] |
+| `lib/core/bootstrap/{tasks,runner,args_parser}.sh` | `bootstrap.BootstrapTask` beans + `TaskRunner` + `BootstrapReport` | **Theme F** always-prints-success lie (149); unparsed $1/$2 options (128) — [S] |
+| `bootstrap/dependencies.sh` (sdkman/docker/ansible) | `bootstrap.DependencyInstaller` strategies (CDI) | **Theme F** silently-dropped -tools tokens (136,138) — [S] |
+| `commands/maintenance/update.sh` | `bootstrap.SelfUpdateCommand` + `BinaryUpdater` + `ChecksumVerifier` + `GitHubReleaseClient` | **Theme G/H** unguarded reset (146); unverified update (162) — [S]; cross-device atomic-move, TLS/CA — [C] |
+| `commands/maintenance/delete.sh` (safe delete, create_vault_backup) | `extension.SafeFsRemover` + `PathGuardTest` denylist; vault backups never serialise Secret | **R5/Theme H** rm -rf on config paths + sed injection (147,163,168); secret in /tmp BACKUP_INFO.txt (160) — [S] |
+| `lib/init.sh` source loader / double-sourcing, SOT_ROOT probing | `runtime.SotPaths` + Quarkus Arc bean graph | **R4 / Theme E** library load model, double-source, SCRIPT_ROOT drift (117) — [S] |
+| `modules/ansible/**`, templates, docker (loose tree) | `src/main/resources/**` + `AssetExtractor` (+ `assets/manifest.txt`) | asset embedding for native — [S]; manifest completeness — [C] |
+| `tests/{run-all,setup-env,unit/*,integration/*}.sh` + mock ansible-vault | `@QuarkusTest` suites + `RecordingProcessRunner` + `FakeToolPathResource` + `CliMainTest` + `ConfigRoundtripTest` + `VaultBehaviorTest` | **Theme K** grep-string tests (integration.sh:56/78), `set -e` counter footgun, zero coverage, bash>=4/macOS 3.2 (201) — [S] |
+| `.github/workflows/{test,lint,security,deploy}.yml`, `.pre-commit-config.yaml`, `tests/run-all.sh` 7-suite list | `ci.yml` + `native-build.yml` + `release.yml` + `jreleaser.yml` (+ scoped pre-commit) | **R7** false-green security.yml `\|\| true`, ci/ dir drift; **Theme I** informational-not-gating (175) — [S]; native musl/exec assumption — [C] |
+| doctor (untested Bash diagnostics) | `doctor.DoctorService` + `cli.DoctorCommand` + `DoctorServiceTest` | **Theme K** untested doctor gap — [S] |
+
+**Findings summary (of the 88):** The large majority dissolve **structurally [S]** — they were artefacts of Bash's dynamic model (string dispatch, `source` loading, unquoted word-splitting, positional argv, dir-glob CI, per-getter re-parse) and cannot recur in a typed, CDI-wired, single-binary design (R1, R2, R3, R4-layout, R6, R7 and themes A, B, D, E, F, I, J, K are essentially eliminated). A residual set still needs **deliberate design care [C]**, all captured in §5/§6: (1) native-image reflection/resource registration for Jackson+SnakeYAML records; (2) the **static-musl-vs-fork/exec** contradiction; (3) tmpfs guarantee + secure-delete + `/dev/shm` symlink race for secrets on non-Linux/container hosts; (4) legacy-config migration; (5) cross-device atomic self-replace + TLS/CA for self-update; (6) `assets/manifest.txt` completeness. Theme **L** is *not tagged in any layer's `dissolvesFindings`* — no layer claims it (flagged in §7).
+
+---
+
+## 5. Native-Image Constraints (consolidated)
+
+**Reflection registration (Jackson + SnakeYAML)**
+- `@RegisterForReflection` on ALL Jackson-mapped records — config (`SotConfig` + all section records), `ExtensionManifest`/`Requirements`/`Dependency`/`RemoteCapabilityDef` + `CapabilityType`, `VaultSecrets`, GitHub-release DTOs. Centralise in `runtime.ReflectionConfig(targets={…})`; records are reflectively constructed by ObjectMapper and fail at runtime with missing-constructor otherwise.
+- SnakeYAML backend needs reflective registration (constructor/introspector classes) or restrict to `tree + treeToValue` to minimise surface. Explicit `@RegisterForReflection` guards against dead-code stripping of record accessors. Verify with a native integration test that round-trips a full config (`#`-in-quotes, apostrophes, all sections).
+- picocli: `@Command/@Option/@Mixin` auto-registered by quarkus-picocli; but `IVersionProvider`, `IHelpSectionRenderer`, `IExitCodeExceptionMapper`, and `AutoComplete.GenerateCompletion` are reflectively instantiated → `@RegisterForReflection` each.
+- Hibernate Validator constraint metadata is registered at build time — annotate record components so the extension picks them up.
+
+**Resource embedding + AssetExtractor**
+- `quarkus.native.resources.includes=ansible/**,docker/**,templates/**,config/**,modules/**,assets/manifest.txt` — mandatory or the assets are simply absent from the binary.
+- A native binary **cannot exec files from inside the image** and **cannot `Files.walk` the classpath**. `AssetExtractor` therefore iterates a build-generated `assets/manifest.txt` and copies each entry via `getResourceAsStream` to a writable runtime dir (`SotPaths`/`InstallLayout`) BEFORE ProcessBuilder invokes ansible/git/docker. Extraction is idempotent (content-hash / checksum) and 0700; verify every glob resolves post-build.
+
+**No dynamic classloading (closed-world)**
+- All CDI beans, the Picocli command tree, `@All List<CapabilityProvider>`, and `@All List<BootstrapTask>` are resolved at **build time** — no runtime classpath scanning, no `Class.forName`. Adding a provider/task = adding a compile-time bean, never dropping a `.sh` at runtime. This is the structural replacement for Bash's `source`/`discover_*` model. Extensions remain **git repos orchestrated via process-exec**, never loaded as Java classes.
+
+**Build-time vs runtime init**
+- `$SOT_HOME`/env must be read at **runtime** (`SotPaths` @ApplicationScoped), not captured at build time.
+- Build-time-init the `YAMLMapper`/`ObjectMapper` via `@Produces` + customizer; version/commit baked into a generated properties resource (`BuildInfo`), no runtime `git` call.
+- `SecureRandom` and security providers must `--initialize-at-run-time` so keys aren't baked into the binary (Quarkus default — verify).
+
+**Charsets & locale**
+- `quarkus.native.add-all-charsets=true` + explicit UTF-8 `file.encoding` so German UTF-8 output and non-ASCII vault content encode correctly; assert in the native smoke test.
+
+**Process exec & static-linking (critical)**
+- `ProcessBuilder`/`ProcessImpl` uses `posix_spawn` in native with no config. **BUT fully-static (musl) native images cannot fork/exec external processes** — the whole tool shells out to ansible/git/docker, so Linux must be **mostly-static (glibc) or dynamic**, NOT `--static --libc=musl`. (This directly contradicts the bootstrap + ci-cd layers, which both chose `--static --libc=musl` for portability — see §6/§7.) `ToolPreflight`/`doctor` must fail fast when a tool is absent. CI must assert real subprocess exec from the built binary (`FakeToolPathResource`).
+- `java.nio` `Files.createTempFile` + `PosixFilePermissions` (0600/0700) work natively on Linux with no reflection — the mechanism for secret files. macOS lacks `/dev/shm` tmpfs (vault `TransientPasswordFile` assumption).
+
+**TLS / self-update**
+- JDK `HttpClient` over TLS for release download requires `quarkus.ssl.native=true` (+ https URL handler) and a CA truststore embedded at build time; allow `-Djavax.net.ssl.trustStore` override. SHA-256 `MessageDigest` (SUN provider) is registered by default.
+- `@QuarkusMainIntegrationTest` (black-box native) cannot inject Mockito/@Alternative → native tests use `FakeToolPathResource` real fake-tool scripts on PATH.
+
+---
+
+## 6. Risks (consolidated) — top 8
+
+1. **Static-musl vs fork/exec contradiction (architecture-breaking).** Bootstrap + ci-cd chose `--static --libc=musl` Linux binaries; the process layer states musl-static *cannot* fork/exec — and the entire tool shells out to ansible/git/docker. **Mitigation:** build **mostly-static (glibc)** or dynamic Linux images; encode libc in the asset name; CI must assert `ProcessBuilder` exec works in the built native binary before any release. *(Must be resolved before native packaging is finalised.)*
+2. **Native-image reflection/resource miss surfaces only at runtime** as a silent empty/half-bound config or missing assets. **Mitigation:** centralise `@RegisterForReflection` in `ReflectionConfig`; a mandatory native `@QuarkusIntegrationTest` that loads `default_config.yml`, parses every real `module.yml`, and runs a runner dry-run — turning a runtime reflection failure into a caught CI failure. Build-time assertion that every `resources.includes` glob + `manifest.txt` entry resolves.
+3. **Secret residual exposure.** `char[]` `Secret` can still surface in a heap/GC copy before zeroing; secure-delete is unreliable on CoW/SSD/journaled FS; a 0600 tmpfs file is briefly root-readable. **Mitigation:** confidentiality rests on tmpfs(RAM)+0600+immediate-unlink+SecureRandom-name+O_EXCL/NOFOLLOW (kills the epoch-name symlink race, finding 165); overwrite is best-effort defence-in-depth; try-with-resources bounds lifetime; disable core dumps; accept documented residual risk.
+4. **tmpfs absent / not-tmpfs (containers, macOS).** `/dev/shm` may be missing or persistent-disk-backed, silently writing the password to disk. **Mitigation:** `PosixGuards` verifies the dir is a real tmpfs mount and **fails loud** rather than silently persisting; this also gates macOS support (no `/dev/shm`).
+5. **Legacy `config.yaml` migration.** Existing files carry dead v1 `integrations` blocks / renamed keys and fail strict binding. **Mitigation:** one-time migration reader (`FAIL_ON_UNKNOWN=false` + `MigrationModule` mapping old→canonical keys) that rewrites to the new schema, then flips to strict; same pattern for legacy flat `<name>_enabled`/`<name>_repo_url` → `RemoteCapabilityDef` and `capabilities.yml`.
+6. **Destructive `RESET_HARD` data-loss regression** from Bash `update.sh`. **Mitigation:** `SyncMode.RESET_HARD` requires an explicit `--force` gate; `PULL` is the default; both paths are one audited `GitService` method.
+7. **Self-replacing binary fails cross-device / EACCES**, or TLS/CA breaks release download. **Mitigation:** write the temp binary into the *target's own parent directory*, verify checksum + cosign before `Files.move(ATOMIC_MOVE)`, fall back to a clear "run install.sh as root" message on EXDEV/EACCES; embed CA bundle at build time with an override + manual-download fallback.
+8. **Long/flaky multi-arch native builds & GraalVM/Mandrel drift** produce non-reproducible binaries. **Mitigation:** PRs run JVM verify + one `linux-amd64` native smoke; the full 4-arch matrix runs only on tag/release (`fail-fast:false` isolates arch failures); pin the exact Mandrel version + `ubi9-mandrel-builder-image` tag; Renovate/Dependabot bumps via a PR that must pass the native gate.
+
+*(Also tracked, lower rank: pipe-buffer deadlock on chatty ansible runs → two virtual-thread drainers; `ansible-vault edit` needs a real TTY → `inheritIO()` only on the interactive path; jqwik generating YAML-unroundtrippable values → constrain generators to validation rules; mocked ProcessRunner drifting from real CLI contracts → an opt-in `@Tag("real-tools")` suite; SonarCloud treated as informational → bind Quality Gate as a required branch-protection check.)*
+
+---
+
+## 7. Open Questions / Decisions the design surfaced
+
+1. **Root package name (must be settled first).** Layers proposed 5 different roots: `de.jklein.sot` (foundation, = Maven groupId), `de.sot` (cli, vault-as `de.sot.security.vault`), `dev.sot` (config, capability), `com.sot` (process/`exec`), `io.sot` (bootstrap). **Decision taken here:** canonicalise on `de.jklein.sot.*` (matches groupId). Every sibling must be re-homed.
+2. **"Capability" vs "Extension" naming split.** The extension layer models everything as `Capability*` (CapabilityService/Provider/Registry, package `capability`), but the CLI layer injects `ExtensionService` and the foundation names the package `extension/`. Same for `ExtensionsCommand` vs `CapabilityService`. Needs one vocabulary — pick Capability internally or Extension throughout.
+3. **`ProcessRunner`: interface vs concrete bean.** The process layer defines it `@ApplicationScoped` concrete; the testing layer *requires it to be an interface* (for `@InjectMock` and the `@Alternative RecordingProcessRunner`). Resolve as **interface + `ProcessRunnerImpl`** (assumed in the tree above).
+4. **Install root default disagreement.** Foundation `SotPaths` default `/opt/SOT`; bootstrap `InstallLayout` default `/opt/sot`; the binary itself installs to `/usr/local/bin/sot`; legacy Bash used `/opt/AAT` + `/etc/DevOpsToolkit`. One canonical `rootDir` + case convention must be chosen (and `SotPaths` vs `InstallLayout` are two overlapping path models to merge into one).
+5. **Static vs mostly-static native linking (see Risk #1).** Direct contradiction: process layer says musl-static breaks fork/exec; bootstrap + ci-cd both ship `--static --libc=musl`. Must decide **mostly-static glibc / dynamic** (required for shelling out) vs the portability the others assumed.
+6. **Overlapping "single shared" beans to dedupe.** Multiple layers each claim to own the one YAML mapper (`runtime.YamlMapperProducer` vs `config.YamlConfigCodec`/`YamlMapperProducer` vs `extension.ManifestParser`'s own `ObjectMapper(YAMLFactory)`); the one `Secret` type (defined in both vault and process); secret-materialisation (vault `TransientPasswordFile`+`SecretResolver` vs process `SecretMaterializer`); asset extraction (`runtime.AssetExtractor` vs `process.WorkspaceManager` vs `bootstrap.AssetExtractor`); `ProcessRunner` (process vs bootstrap vs vault's direct `AnsibleVaultRunner`). Each must collapse to a single shared implementation.
+7. **Self-update mechanism coexistence.** Two update paths exist: in-binary `sot self-update` (bootstrap: HttpClient + atomic swap + re-exec) and `install.sh` re-download. Decide whether both are supported and which is canonical; ci-cd added **cosign signature** verification that the foundation's simpler `shasum`-only `install.sh` lacks — align them.
+8. **macOS support is only partially coherent.** Release matrix (foundation/ci-cd) and `install.sh` (uname darwin) target macOS arm64, but (a) native static-linking is Linux-only anyway, and (b) the vault layer's tmpfs secret handling (`/dev/shm`/`XDG_RUNTIME_DIR`) has no macOS equivalent. Define the macOS secret-file strategy or scope macOS out.
+9. **Keeping Ansible/Terraform/Docker.** Unanimous and unchanged — all remain external processes shelled out via `ProcessBuilder`, with playbooks/roles embedded as resources; no layer proposed removing Ansible. (Recorded as a settled decision, not an open one.)
+10. **`module.yml` schema evolution / backward-compat window.** Extension layer wants `apiVersion` + a warn-not-fail validation window for older manifests lacking newer nested fields; interacts with the config migration reader (Risk #5) — one migration policy should cover both.
+11. **Theme L is unaccounted for.** No layer's `dissolvesFindings` references theme **L** (themes A-K are all covered). Either L maps to a subsystem no agent was assigned (candidate: logging/observability or the maintenance/delete surface, only partially covered by `PathGuardTest`/`TeeSink`), or the theme list is off-by-one. Confirm what L is and which component owns it before claiming full 88-finding coverage.

--- a/docs/java-quarkus-nix-substrate-brief.md
+++ b/docs/java-quarkus-nix-substrate-brief.md
@@ -1,0 +1,671 @@
+# SOT — Nix Substrate & Cross-Platform Delivery: Consolidated Brief
+
+Source: 4 architecture agents — `nix-substrate-and-dependencies`, `app-install-and-update-via-nix`, `cli-as-flake-and-cross-platform`, `windows-wsl-bootstrap`. All four rated effort **L**.
+
+Core thesis (shared across all areas): **Nix becomes the single package substrate.** `bootstrap.DependencyInstaller` (apt/sdkman/docker/ansible) and the `AptDeb`/`APT_DEB` path are DELETED. Every tool, app, and the SOT CLI itself arrive via `nix profile install` from a signed binary cache (download-only, no compile). One Java gateway — `NixService` over the shared `ProcessRunner` — is the only class that shells `nix`.
+
+---
+
+## 1. Per-Area Design
+
+### 1.1 nix-substrate-and-dependencies
+
+A new `de.jklein.sot.nix` package makes Nix the single substrate, DELETING `bootstrap.DependencyInstaller` and the `AptDeb`/`APT_DEB` source path. `NixService` (`@ApplicationScoped`, `NixServiceImpl`) wraps the `nix` CLI through the shared `ProcessRunner` — never `Runtime.exec` — exposing probe/ensure/profile/flake/config verbs. `probe()` returns a `NixEnvironment` record (present, version, flakesEnabled, daemonMode, `insideNixOS` via `/etc/NIXOS`, `system`, substituters). All flake calls pass `--extra-experimental-features "nix-command flakes"`; `ensureExperimentalFeatures()` persists them to `~/.config/nix/nix.conf` idempotently. `ToolchainManager` owns a SOT-generated flake at `$SOT_HOME/toolchain/flake.nix` (Qute-rendered by `ToolchainFlakeRenderer`) whose `packages.<system>.toolchain` is a `pkgs.buildEnv` over the declared tool list with a pinned `nixpkgs` input + committed `flake.lock` = full reproducibility, installed into a DEDICATED profile `--profile $SOT_HOME/state/profile` (never the user default). `NixToolchainReconciler` (bootstrap + doctor) computes DESIRED = core tools ∪ every installed app's `requires.tools` (from `InstalledAppStore`), maps via `NixPackageCatalog` (toolId→nixpkgs attr + `NixPkgKind`), re-renders, and runs `profileInstall`/`profileUpgrade` — 100% runtime-dynamic, no Java rebuild. `NixInstaller.ensure()` is the idempotent Determinate-installer fallback, SKIPPED when `insideNixOS`. `NixBootstrapTask` does ensure-nix → ensure-cache → reconcile; `NixDoctorCheck` reports nix/flakes/cache/tools/docker-daemon. `SYSTEM_SERVICE` tools (docker daemon) can't be profile packages on non-NixOS — doctor delegates (NixOS-WSL `virtualisation.docker.enable`, macOS colima/Docker Desktop).
+
+- `NixService` — interface + `@ApplicationScoped` impl — the one gateway to nix (probe, profile install/upgrade/remove/list, build, eval, flake metadata/update, run, substituter config).
+- `NixEnvironment` — record — detected substrate facts; drives skip-when-NixOS and single-vs-multi-user decisions.
+- `ToolchainManager` + `ToolchainFlakeRenderer` — `@ApplicationScoped` + Qute template — owns/renders `$SOT_HOME/toolchain/flake.nix` (buildEnv + pinned nixpkgs + flake.lock), installs one atomic profile entry.
+- `NixToolchainReconciler` — `@ApplicationScoped` — desired set = core ∪ union(apps' requires.tools); replaces `DependencyInstaller`.
+- `NixPackageCatalog` + `NixPackageRef` — `@ApplicationScoped` + record — toolId → nixpkgs attr + `NixPkgKind` (PROFILE_PKG vs SYSTEM_SERVICE); overridable via `SotConfig.tools`.
+- `NixInstaller` — `@ApplicationScoped` — idempotent Determinate nix-installer ensure; no-op inside NixOS.
+- `NixBootstrapTask` — `BootstrapTask` bean — plugs ensure + cache + reconcile into the TaskRunner pipeline.
+- `NixDoctorCheck` — `DoctorService` check — nix/flakes/cache/tools/docker socket.
+- `BinaryCacheConfig` + `BinaryCache` — `@ApplicationScoped` + record — idempotently ensures SOT substituter + trusted-public-key.
+
+**Effort: L**
+
+### 1.2 app-install-and-update-via-nix
+
+Nix becomes the PRIMARY app substrate. `AppSourceType` ADDS `NIX` (nixpkgs attribute) + `NIX_FLAKE` (flake installable ref), KEEPS `DOCKER_COMPOSE`/`GIT_REPO`/`SCRIPT`, REMOVES `APT_DEB` (old `AptDebStrategy` + the sdkman/docker/ansible `DependencyInstaller` deleted). Two new `InstallStrategy` beans — `NixpkgsInstallStrategy` (`type()==NIX`) and `NixFlakeInstallStrategy` (`type()==NIX_FLAKE`) — delegate to a shared `NixProfileManager` wrapping `nix` via a thin `NixCli` in `process/`. Default model = a PER-APP profile at `{stateRoot}/profiles/<appId>` (independent generations, atomic rollback, clean removal), then symlinks `<profile>/bin/*` into the sot-managed `{binRoot}` on PATH. `install()` runs `nix profile install --profile {p} <installable>`; NIX uses a locked `github:NixOS/nixpkgs/<pinnedRev>#<attr>`, NIX_FLAKE uses `source.flakeRef` (flake's own `flake.lock` pins transitively). Both honor the owner binary cache. `update()` = `nix profile upgrade`; `remove()` = `nix profile remove` + delete profile dir + bin symlinks. A `nix build .#attr --out-link` (`mode: build`) variant exists but profiles are default. `NixToolProvisioner` provisions system tools (git/docker/ansible/terraform) into ONE shared `system` profile — docker still comes FROM Nix; `DockerComposeStrategy` shells to that nix-provided `docker compose`. Update-monitoring gets `UpdateStrategy.NIX`/`NIX_FLAKE` (drops `APT`). `NixVersionResolver` reads installed locked rev from `nix profile list --json` and upstream from `nix flake metadata <ref> --json` (`.locked.rev`/`.lastModified`) or `nix eval --raw <nixpkgsRef>#<attr>.version`; folds into `UpdateMonitorService.checkAll()` virtual-thread fan-out. EXACT pin ⇒ frozen locked rev in `installed.yml`; RANGE ⇒ upgrade within a nixpkgs branch/rev window.
+
+- `AppSourceType` — enum — ADD NIX + NIX_FLAKE; KEEP GIT_REPO, DOCKER_COMPOSE, SCRIPT; REMOVE APT_DEB. Selects strategy via `@All Map<AppSourceType,InstallStrategy>`.
+- `NixpkgsInstallStrategy` — CDI bean (InstallStrategy) — `type()==NIX`; installs locked `github:NixOS/nixpkgs/<rev>#<attr>` into per-app profile.
+- `NixFlakeInstallStrategy` — CDI bean (InstallStrategy) — `type()==NIX_FLAKE`; installs flake installable, relies on flake.lock for transitive pinning.
+- `NixProfileManager` — class (app/) — shared engine: profile install/upgrade/remove into `{stateRoot}/profiles/<appId>`, generation rollback, bin symlinking, optional `nix build --out-link`.
+- `NixCli` — class (process/) — thin typed wrapper over ProcessRunner for the nix binary (build/eval/profile/flake-metadata, `--json`, substituter flags).
+- `NixToolProvisioner` — class (bootstrap/ or process/) — replaces DependencyInstaller; installs system tools into one shared `system` profile.
+- `UpdateStrategy` — enum — ADD NIX + NIX_FLAKE, REMOVE APT; keeps GITHUB_RELEASE, GIT_TAG, DOCKER_IMAGE, STATIC, SCRIPT.
+- `NixVersionResolver` — CDI bean (VersionResolver, app.update/) — reads installed locked rev + resolves upstream; emits `ResolvedVersion(rev as digest)`.
+- `NixSourceSpec` / `NixFlakeSourceSpec` — records — `@RegisterForReflection` Jackson slices bound in `resolve()`.
+
+**Effort: L**
+
+### 1.3 cli-as-flake-and-cross-platform
+
+SOT itself becomes a Nix flake at the repo root; `nix profile install` (backed by a binary cache) replaces the old "curl install.sh → download GitHub-Release asset → sha256/cosign → /usr/local/bin" path. GitHub Releases stays the artifact store (JReleaser publishes `sot-<os>-<arch>`), but `packages.<system>.default` is a `fetchurl`-wrapper derivation pinning each asset by SHA-256; Cachix serves the realized `/nix/store` path as a signed CDN. **BUILD CHOICE: fetchurl-wrapper over gradle2nix for v1** — a reproducible from-source GraalVM/Mandrel `native-image` build in the pure Nix sandbox is heavy/brittle across 4 systems and buys no UX gain (cache means download-anyway). The flake wraps the CI-built binary with `fetchurl` + `autoPatchelfHook` (Linux, `stdenv.cc.cc.lib`+`zlib` buildInputs) and plain `install -Dm755` on darwin (Mach-O, no patchelf); gradle2nix is a future `packages.sot-src`. Flake enumerates `x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin` via `flake-utils.eachSystem`. macOS is first-class (CI adds `macos-14`/`macos-13` runners). Windows delegated to WSL sibling. Java: new `de.jklein.sot.nix.NixService` port (process/); `bootstrap.SelfUpdateCommand`/`BinaryUpdater` rewritten to `nix profile upgrade sot`. `install.sh` (Linux+macOS): (1) Determinate `nix-installer` if absent; (2) append `extra-substituters`/`extra-trusted-public-keys`; (3) `nix profile install github:NiklasJavier/SOT --accept-flake-config`; (4) print `sot bootstrap`. Flake declares `nixConfig.extra-substituters` so `--accept-flake-config` self-configures. Cachix (managed) for v1; self-hosted attic (`cache.jklein.de`) as sovereignty option. macOS secrets: no tmpfs — `TransientPasswordFile` falls back to `mkstemp` 0600 on encrypted APFS `$TMPDIR`.
+
+- `flake.nix` — nix-flake (repo root) — inputs=nixpkgs(+flake-utils); outputs packages/apps/devShells for 4 systems; nixConfig declares cache.
+- `packages.<system>.default (mkSot)` — Nix derivation — fetchurl-wrapper, SHA-256-pinned; autoPatchelfHook (Linux) / plain install (darwin); `meta.mainProgram=sot`.
+- `apps.default` — Nix app output — `flake-utils.mkApp` so `nix run github:NiklasJavier/SOT` works.
+- `devShells.default` — Nix devShell — jdk21 + gradle + just + mandrel/graalvm + native toolchain.
+- `install.sh` — POSIX bootstrap — install Nix if absent → write cache → nix profile install → next-steps.
+- `de.jklein.sot.nix.NixService` — Java port (process/) — typed wrapper for profile install/upgrade/list/remove + build.
+- `bootstrap.SelfUpdateCommand` / `NixSelfUpdater` — Java CLI command — self-update = `nix profile upgrade sot`; retires the GitHub-Release re-download `BinaryUpdater`; atomic, no re-exec/ATOMIC_MOVE.
+- `.github/workflows/release.yml` — CI — build native → JReleaser publish → compute SHA-256 → update flake hashes → `nix build .#default` per runner → `cachix-action@v17` push.
+- Cachix cache (`sot`) / attic — binary cache — serves prebuilt native store paths; attic self-hosted as sovereign alt.
+
+**Effort: L**
+
+### 1.4 windows-wsl-bootstrap
+
+Windows = a *thin Windows-side bootstrapper + shim*; ALL real logic runs inside a NixOS-WSL Linux env where the ordinary Linux `install.sh` + Nix path runs unchanged. No Windows-native GraalVM target — the native binary stays Linux-only, executed inside WSL. New assets under `dist/windows/` served at `https://<host>/cli/`: `install.ps1`, `sot.cmd` + a compiled single-file `sot.exe` shim (Rust/Go), and the `nixos.wsl` tarball (+`.sha256`). Only two Java touchpoints: `de.jklein.sot.runtime.WslEnvironment` (record; detects WSL via `$WSL_DISTRO_NAME` / `/proc/sys/kernel/osrelease` so doctor, `UpdateNotifier` Windows toast, `SotPaths` adapt) and `de.jklein.sot.bootstrap.windows.WindowsShimWriter` (CI-only shim regeneration). `install.ps1` is an idempotent, reboot-resumable state machine driven by `$env:SOT_RESUME`: **0 Preflight** (build ≥19041, self-elevate `Start-Process -Verb RunAs`, virtualization); **A Ensure WSL2** (`wsl --install --no-distribution`, RunOnce re-invoke with `SOT_RESUME=B` + reboot if pending); **B Install NixOS-WSL** (idempotent `wsl -l -q` scan, download+verify `nixos.wsl`, `wsl --install --from-file` on WSL ≥2.4.4 else `wsl --import NixOS $dataDir nixos.wsl --version 2`); **C Provision sot** (`wsl -d NixOS -u root -- bash -lc "curl … install.sh | bash"` → reduces to `nix profile install github:NiklasJavier/SOT` from cache); **D Shim** (copy `sot.exe`/`sot.cmd` to `%LOCALAPPDATA%\Programs\sot\bin`, prepend PATH, broadcast `WM_SETTINGCHANGE`). The shim forwards argv + stdio + exit code to `wsl.exe -d NixOS -e sot …`; line-oriented selector (no JLine) reads ConPTY under Windows Terminal, degrades to `list` when `System.console()==null`. Docker/systemd run inside NixOS-WSL (no Docker Desktop); services reachable on `localhost` via localhostForwarding (mirrored networking recommended on Win11). Self-update stays Linux-side.
+
+- `install.ps1` — powershell-script — reboot-resumable state machine; `irm https://<host>/cli/install.ps1 | iex`.
+- `sot.exe` — compiled shim (Rust/Go) — primary PATH entry; spawns `wsl.exe -d NixOS -e sot <argv>` with faithful argv, inherited ConPTY, propagated exit code.
+- `sot.cmd` — cmd-shim — zero-dependency fallback (`wsl.exe -d NixOS -e sot %*`).
+- `nixos.wsl` — nix-wsl-tarball — NixOS-WSL rootfs (wsl.enable + systemd + docker + cache substituters), sha256-verified, imported as distro `NixOS`.
+- `WslEnvironment` — java-record (runtime/) — runtime WSL detection; doctor/notifier/SotPaths adapt.
+- `WindowsShimWriter` — java-class (bootstrap/windows) — CI-time shim generator/validator; not at user runtime.
+- `/cli/` asset set — http-assets (owner host) — single distribution surface: install.sh, install.ps1, nixos.wsl(+.sha256), sot.exe/sot.cmd, manifest.json.
+
+**Effort: L**
+
+---
+
+## 2. Concrete Schemas, Interfaces & Nix/Shell Snippets (VERBATIM)
+
+### 2.1 `NixService` — the two published shapes
+
+**Area nix-substrate-and-dependencies** (full port):
+
+```java
+public interface NixService {
+  NixEnvironment probe();                         // detect nix, version, flakes, daemon, NixOS, system
+  boolean        isNixPresent();
+  void           ensureExperimentalFeatures();    // persist + pass 'nix-command flakes'
+
+  ProfileList profileList(NixProfileRef p);        // nix profile list --json
+  NixResult   profileInstall(NixProfileRef p, FlakeRef ref);
+  NixResult   profileUpgrade(NixProfileRef p, String nameOrAll);
+  NixResult   profileRemove(NixProfileRef p, String name);
+
+  NixResult      build(FlakeRef ref);              // nix build <ref> --no-link --print-out-paths
+  JsonNode       eval(FlakeRef ref, String attr);  // nix eval <ref>#<attr> --json
+  FlakeMetadata  flakeMetadata(FlakeRef ref);      // nix flake metadata <ref> --json
+  NixResult      flakeUpdate(Path flakeDir);       // nix flake update (bump flake.lock, gated)
+  NixResult      run(FlakeRef ref, List<String> appArgs); // nix run <ref> -- <args>
+
+  void      ensureSubstituter(BinaryCache cache);  // add substituter + trusted-public-key idempotently
+  NixConfig currentConfig();                        // nix config show --json (subset)
+}
+```
+
+Supporting records/enums (same area):
+
+```java
+record NixEnvironment(boolean present, Optional<String> version, boolean flakesEnabled,
+                      boolean daemonMode, boolean insideNixOS, String system,
+                      List<String> substituters) {}
+record FlakeRef(String value) {                     // "nixpkgs#git", "github:NiklasJavier/SOT", "/home/u/.sot/toolchain#toolchain"
+  static FlakeRef nixpkgs(String attr){ return new FlakeRef("nixpkgs#"+attr); } }
+record NixProfileRef(Path path) {}                  // $SOT_HOME/state/profile (isolated from user default)
+record ProfileEntry(int index, String name, String storePath, List<String> flakeRefs) {}
+record ProfileList(List<ProfileEntry> entries) {}
+record FlakeMetadata(String resolvedUrl, String lockedRev, Instant lastModified, JsonNode raw) {}
+record NixResult(int exitCode, String stdout, String stderr, Duration took){ boolean ok(){return exitCode==0;} }
+record BinaryCache(String url, String publicKey) {}
+enum   NixPkgKind { PROFILE_PKG, SYSTEM_SERVICE }
+record NixPackageRef(String toolId, String nixAttr, NixPkgKind kind, Optional<String> minVersion) {}
+```
+
+**Area cli-as-flake-and-cross-platform** (thinner port variant, `de.jklein.sot.nix.NixService`):
+
+```java
+public interface NixService {
+  NixResult profileInstall(String flakeRef);      // nix profile install <ref> --accept-flake-config
+  NixResult profileUpgrade(String name);          // nix profile upgrade sot  (self-update)
+  List<NixProfileEntry> profileList();            // nix profile list --json
+  NixResult install(String pkg);                  // nix profile install nixpkgs#<pkg>  (tools: git/ansible/...)
+}
+// backed by shared ProcessRunner; used by SelfUpdateCommand + DependencyInstaller (nix-substrate area)
+```
+
+### 2.2 `InstallStrategy` contract + `NixProfileManager` (area app-install-and-update-via-nix)
+
+```java
+public interface InstallStrategy {              // unchanged contract; NIX/NIX_FLAKE are new impls
+  AppSourceType type();                         // NIX | NIX_FLAKE | GIT_REPO | DOCKER_COMPOSE | SCRIPT
+  ResolvedSource resolve(AppManifest m, InstallContext ctx);
+  InstallOutcome install(ResolvedSource s, InstallContext ctx);
+  InstallOutcome update (ResolvedSource s, InstalledApp cur, InstallContext ctx);
+  void           remove (InstalledApp cur, InstallContext ctx);
+}
+```
+
+```java
+final class NixProfileManager {
+  Path profileDir(String appId);                                  // {stateRoot}/profiles/<appId>
+  InstallOutcome install(String appId, String installable);        // nix profile install --profile p <installable>
+  InstallOutcome upgrade(String appId, String name);               // nix profile upgrade --profile p <name>
+  void           remove (String appId);                            // nix profile remove + unlink bin/*, rm profile
+  void           linkBinaries(String appId);                       // symlink <profile>/bin/* -> {binRoot}
+  String         lockedRev(String appId);                          // from `nix profile list --json`
+}
+```
+
+### 2.3 `NixVersionResolver` + `UpdateStrategy` (area app-install-and-update-via-nix)
+
+```java
+interface VersionResolver { UpdateStrategy strategy(); ResolvedVersion resolveLatest(VersionQuery q, ResolverContext ctx); }
+@ApplicationScoped
+class NixVersionResolver implements VersionResolver {
+  // registered for BOTH NIX and NIX_FLAKE via a small StrategySet, or two thin subclasses
+  public UpdateStrategy strategy() { return UpdateStrategy.NIX_FLAKE; }
+  public ResolvedVersion resolveLatest(VersionQuery q, ResolverContext ctx) {
+    // NIX_FLAKE: nix flake metadata <ref> --json -> node.at("/locked/rev") + /locked/lastModified
+    // NIX:       nix eval --raw <nixpkgsRef>#<attr>.version
+    // returns ResolvedVersion(latest, rawLatest, digest=rev, at, cache)
+  }
+}
+enum UpdateStrategy { NIX, NIX_FLAKE, GITHUB_RELEASE, GIT_TAG, DOCKER_IMAGE, STATIC, SCRIPT }  // APT removed
+```
+
+### 2.4 Revised `app.yml` source/version blocks
+
+**nixpkgs attribute app** (area app-install-and-update-via-nix):
+
+```yaml
+# app.yml — nixpkgs attribute app (system tool or CLI)
+source:
+  type: nix                       # -> NixpkgsInstallStrategy
+  attr: terraform                 # nixpkgs attribute
+  nixpkgs: github:NixOS/nixpkgs/nixos-24.05   # optional channel/rev pin (else global default pin)
+  mode: profile                   # profile (default) | build   (build => nix build --out-link)
+version:
+  strategy: nix                   # -> NixVersionResolver (NIX)
+  constraint: '>=1.7.0 <2.0.0'    # applied to nixpkgs attr .version when SemVer-parseable
+```
+
+**flake app** (area app-install-and-update-via-nix):
+
+```yaml
+# app.yml — flake app (owner's own app, incl. SOT-catalog apps)
+source:
+  type: nix-flake                 # -> NixFlakeInstallStrategy
+  flakeRef: github:NiklasJavier/grafana-stack   # flake installable
+  attr: default                   # outputs.packages.<system>.<attr> (default)
+  rev: v10.4.0                    # optional explicit pin; else flake.lock governs
+version:
+  strategy: nix-flake             # -> NixVersionResolver (NIX_FLAKE)
+  # compares installed locked rev vs `nix flake metadata --json` .locked.rev
+```
+
+**docker-compose app; docker itself comes FROM nix** (area app-install-and-update-via-nix):
+
+```yaml
+# app.yml — docker-compose app; docker itself comes FROM nix
+source:
+  type: docker-compose
+  repoUrl: https://github.com/NiklasJavier/monitoring
+  composeFile: docker-compose.yml
+requires:
+  tools: [docker]                 # NixToolProvisioner.ensure("docker") -> shared system nix profile
+```
+
+**nix source + version block (area nix-substrate-and-dependencies variant):**
+
+```yaml
+# app.yml — nix source + version block (replaces apt-deb)
+source:
+  type: nix                      # AppSourceType.NIX (reuses NixService.profileInstall)
+  attr: nixpkgs#hello            # or a flake: github:owner/app#default
+  flakeRef: github:NixOS/nixpkgs/nixos-24.11   # optional pin for reproducibility
+version:
+  strategy: nix                  # NixVersionResolver: nix eval <attr>.version / flake metadata
+  attr: nixpkgs#hello
+```
+
+### 2.5 `NixPackageCatalog` defaults (area nix-substrate-and-dependencies)
+
+```
+// NixPackageCatalog defaults (toolId -> nixpkgs attr, kind); overridable via SotConfig.tools
+git->git(PROFILE), ansible->ansible(PROFILE), terraform->terraform(PROFILE) [opentofu default option],
+kubectl->kubectl, helm->kubernetes-helm, jq->jq, yq->yq-go, curl->curl, cosign->cosign,
+age->age, sops->sops, docker-cli->docker-client(PROFILE),
+docker->docker(SYSTEM_SERVICE: NixOS virtualisation.docker / colima / Docker Desktop)
+```
+
+### 2.6 Repo `flake.nix` outline (area cli-as-flake-and-cross-platform)
+
+```nix
+{
+  description = "SOT — dynamic app-manager CLI (native GraalVM)";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  nixConfig = {
+    extra-substituters = [ "https://sot.cachix.org" ];
+    extra-trusted-public-keys = [ "sot.cachix.org-1:BASE64KEY=" ];
+  };
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      version = "1.2.0";                     # single-sourced with JReleaser tag
+      assets = {                              # hashes regenerated by CI per release
+        "x86_64-linux"   = { file = "sot-linux-amd64";  hash = "sha256-AAAA..."; };
+        "aarch64-linux"  = { file = "sot-linux-arm64";  hash = "sha256-BBBB..."; };
+        "x86_64-darwin"  = { file = "sot-darwin-amd64"; hash = "sha256-CCCC..."; };
+        "aarch64-darwin" = { file = "sot-darwin-arm64"; hash = "sha256-DDDD..."; };
+      };
+    in flake-utils.lib.eachSystem (builtins.attrNames assets) (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        a = assets.${system};
+        linux = pkgs.stdenv.isLinux;
+        sot = pkgs.stdenv.mkDerivation {
+          pname = "sot"; inherit version;
+          src = pkgs.fetchurl {
+            url = "https://github.com/NiklasJavier/SOT/releases/download/v${version}/${a.file}";
+            hash = a.hash;
+          };
+          dontUnpack = true;
+          nativeBuildInputs = pkgs.lib.optionals linux [ pkgs.autoPatchelfHook ];
+          buildInputs = pkgs.lib.optionals linux [ pkgs.stdenv.cc.cc.lib pkgs.zlib ];
+          installPhase = ''runHook preInstall; install -Dm755 $src $out/bin/sot; runHook postInstall'';
+          meta.mainProgram = "sot";
+        };
+      in {
+        packages.default = sot; packages.sot = sot;
+        apps.default = flake-utils.lib.mkApp { drv = sot; };
+        devShells.default = pkgs.mkShell {
+          packages = [ pkgs.jdk21 pkgs.gradle pkgs.just pkgs.mandrel ];
+        };
+      });
+}
+```
+
+### 2.7 SOT-managed toolchain flake `$SOT_HOME/toolchain/flake.nix` (area nix-substrate-and-dependencies)
+
+```nix
+# $SOT_HOME/toolchain/flake.nix  (Qute-rendered from the declared tool set; flake.lock committed => reproducible)
+{
+  description = "SOT-managed toolchain";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";      # SOT-pinned channel
+  outputs = { self, nixpkgs }:
+    let systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+        forAll = f: nixpkgs.lib.genAttrs systems (s: f nixpkgs.legacyPackages.${s});
+    in {
+      packages = forAll (pkgs: {
+        toolchain = pkgs.buildEnv {
+          name  = "sot-toolchain";
+          paths = with pkgs; [ git ansible terraform jq ];       # {#each declaredTools} rendered {/each}
+        };
+      });
+    };
+}
+```
+
+### 2.8 Binary-cache `nix.conf` config
+
+**Cachix / owner-cache variant (area app-install-and-update-via-nix):**
+
+```
+# nix.conf (written by bootstrap) — owner binary cache so installs pull prebuilt closures
+experimental-features = nix-command flakes
+substituters = https://cache.nixos.org https://<owner-cache>.cachix.org
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= <owner-cache>.cachix.org-1:<key>
+```
+
+**Self-hosted attic variant (area cli-as-flake-and-cross-platform):**
+
+```
+extra-substituters = https://cache.jklein.de/sot
+extra-trusted-public-keys = sot:BASE64PUBKEY=
+```
+
+### 2.9 Rewritten `install.sh` outline (Linux + macOS)
+
+**Area cli-as-flake-and-cross-platform (canonical):**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+FLAKE="github:NiklasJavier/SOT"
+CACHE_URL="https://sot.cachix.org"
+CACHE_KEY="sot.cachix.org-1:BASE64KEY="
+# 1. Nix present? else Determinate installer (flakes on by default, adds trusted-user)
+if ! command -v nix >/dev/null 2>&1; then
+  curl -fsSL https://install.determinate.systems/nix | sh -s -- install --no-confirm
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+fi
+# 2. Configure the binary cache in the user nix.conf (trusted-user honors these)
+mkdir -p "$HOME/.config/nix"
+if ! grep -q "$CACHE_URL" "$HOME/.config/nix/nix.conf" 2>/dev/null; then
+  cat >>"$HOME/.config/nix/nix.conf" <<EOF
+experimental-features = nix-command flakes
+extra-substituters = $CACHE_URL
+extra-trusted-public-keys = $CACHE_KEY
+EOF
+fi
+# 3. Install SOT from the flake — download-only via the cache, no compile
+nix profile install "$FLAKE" --accept-flake-config
+# 4. Next steps
+echo "sot installed. Next: sot bootstrap"
+```
+
+**Area nix-substrate-and-dependencies (condensed variant, owner-host cache):**
+
+```bash
+# install.sh (Linux/macOS/WSL) — Nix first, then SOT via flake + binary cache
+curl -fsSL https://install.determinate.systems/nix | sh -s -- install --no-confirm   # multi-user daemon, flakes on
+. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+mkdir -p ~/.config/nix
+printf 'substituters = https://cache.nixos.org https://sot.jklein.de/cache\ntrusted-public-keys = cache.nixos.org-1:6NCHdD... sot.jklein.de:BASE64KEY=\n' >> ~/.config/nix/nix.conf
+nix profile install github:NiklasJavier/SOT          # pulls prebuilt GraalVM-native binary from cache
+sot bootstrap                                        # ensures toolchain profile
+```
+
+### 2.10 `install.ps1` outline (area windows-wsl-bootstrap)
+
+```powershell
+# install.ps1 — outline (served at https://<host>/cli/install.ps1)
+#requires -Version 5.1
+$ErrorActionPreference = 'Stop'
+$Host_ = 'https://<owner-host>/cli'
+$Distro = 'NixOS'
+$Resume = $env:SOT_RESUME  # '', 'B' after reboot
+
+function Assert-Admin {
+  $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $p  = New-Object Security.Principal.WindowsPrincipal($id)
+  if (-not $p.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)) {
+    Start-Process powershell -Verb RunAs -ArgumentList \
+      "-NoProfile -Command `"irm $Host_/install.ps1 | iex`""; exit
+  }
+}
+function Set-Resume([string]$stage) {
+  Set-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce' `
+    -Name 'SotResume' -Value "powershell -NoProfile -Command `"$env:SOT_RESUME='$stage'; irm $Host_/install.ps1 | iex`""
+}
+
+Assert-Admin
+if ([Environment]::OSVersion.Version.Build -lt 19041) { throw 'Windows 10 2004+/11 required' }
+
+if ($Resume -ne 'B') {                       # --- Stage A: ensure WSL2 ---
+  $hasWsl = (& wsl.exe --version 2>$null)
+  if (-not $hasWsl) {
+    wsl.exe --install --no-distribution      # enables VM Platform + WSL kernel
+    Set-Resume 'B'; Write-Host 'Rebooting to finish WSL2 setup...'; Restart-Computer -Force; exit
+  }
+  wsl.exe --update --web-download
+}
+
+# --- Stage B: install NixOS-WSL (idempotent) ---
+$installed = (wsl.exe -l -q) -contains $Distro
+if (-not $installed) {
+  $tar = "$env:TEMP\nixos.wsl"
+  Invoke-WebRequest "$Host_/nixos.wsl"        -OutFile $tar
+  Invoke-WebRequest "$Host_/nixos.wsl.sha256" -OutFile "$tar.sha256"
+  $want = (Get-Content "$tar.sha256").Split(' ')[0]
+  if ((Get-FileHash $tar -Algorithm SHA256).Hash -ne $want) { throw 'nixos.wsl checksum mismatch' }
+  $ver = [version]((wsl.exe --version | Select-String 'WSL-Version').ToString().Split(':')[1].Trim())
+  if ($ver -ge [version]'2.4.4') { wsl.exe --install --from-file $tar }
+  else { $d="$env:LOCALAPPDATA\WSL\NixOS"; wsl.exe --import $Distro $d $tar --version 2 }
+}
+
+# --- Stage C: install sot inside the distro (Nix already present) ---
+wsl.exe -d $Distro -u root -- bash -lc "curl -fsSL $Host_/install.sh | bash"
+
+# --- Stage D: drop the Windows shim + PATH ---
+$bin = "$env:LOCALAPPDATA\Programs\sot\bin"; New-Item -Force -ItemType Directory $bin | Out-Null
+Invoke-WebRequest "$Host_/sot.exe" -OutFile "$bin\sot.exe"
+Invoke-WebRequest "$Host_/sot.cmd" -OutFile "$bin\sot.cmd"
+$u = [Environment]::GetEnvironmentVariable('Path','User')
+if ($u -notlike "*$bin*") { [Environment]::SetEnvironmentVariable('Path',"$bin;$u",'User') }
+Write-Host 'Done. Open a new terminal and run: sot app'
+```
+
+### 2.11 Windows `sot` shim (area windows-wsl-bootstrap)
+
+`sot.cmd` (zero-dependency fallback):
+
+```bat
+REM sot.cmd — thin fallback shim (served at /cli/sot.cmd)
+@echo off
+wsl.exe -d NixOS -e sot %*
+exit /b %ERRORLEVEL%
+```
+
+`sot.exe` (Rust — correct argv + stdio + exit-code passthrough):
+
+```rust
+// sot.exe shim (Rust) — correct argv + stdio + exit-code passthrough
+use std::process::{Command, exit};
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let status = Command::new("wsl.exe")
+        .args(["-d", "NixOS", "-e", "sot"]).args(&args)
+        .status().expect("wsl.exe not found — run install.ps1");
+    exit(status.code().unwrap_or(1)); // stdin/stdout/stderr inherited (ConPTY)
+}
+```
+
+### 2.12 NixOS-WSL tarball config + `/cli/` asset manifest (area windows-wsl-bootstrap)
+
+```nix
+# nixos.wsl flake (configuration.nix highlights baked into the tarball)
+{ modulesPath, pkgs, ... }: {
+  imports = [ "${modulesPath}/../nixos-wsl/modules" ]; # NixOS-WSL
+  wsl.enable = true;
+  wsl.defaultUser = "nixos";
+  wsl.startMenuLaunchers = true;
+  systemd.enable = true;                 # required for docker + sot systemd-timer
+  virtualisation.docker.enable = true;   # docker runs INSIDE WSL, no Docker Desktop
+  nix.settings = {
+    experimental-features = [ "nix-command" "flakes" ];
+    substituters = [ "https://<cache>.cachix.org" ];
+    trusted-public-keys = [ "<cache>.cachix.org-1:<key>" ];
+  };
+  system.stateVersion = "24.11";
+}
+```
+
+```
+# What the owner host MUST serve under https://<host>/cli/
+install.sh          # Linux + macOS bootstrap (Determinate nix-installer -> nix profile install)
+install.ps1         # Windows bootstrap (this file)
+nixos.wsl           # NixOS-WSL rootfs tarball  (imported as distro 'NixOS')
+nixos.wsl.sha256    # checksum for the tarball
+sot.exe             # compiled Windows shim (code-signed)
+sot.cmd             # fallback shim
+manifest.json       # { sotVersion, wslMinVersion, distroName, tarballSha256 }
+```
+
+### 2.13 CI release cache push (area cli-as-flake-and-cross-platform)
+
+```yaml
+# release.yml cache push (per-system runner):
+- uses: cachix/cachix-action@v17
+  with:
+    name: sot
+    authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+    signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
+- run: nix build .#default && nix profile install .#default   # realizes + pushes on job end
+```
+
+---
+
+## 3. Full Command & Recipe Surface
+
+### (a) Nix commands SOT runs internally
+
+- `nix profile install --profile {stateRoot}/profiles/<id> github:NixOS/nixpkgs/<rev>#<attr>` — install a NIX (nixpkgs attr) app into its per-app profile.
+- `nix profile install --profile {stateRoot}/profiles/<id> <flakeRef>#<attr>` — install a NIX_FLAKE app (owner cache supplies prebuilt closure).
+- `nix profile install --profile $SOT_HOME/state/profile $SOT_HOME/toolchain#toolchain` — install the SOT-managed toolchain as one atomic, isolated profile entry.
+- `nix profile install github:NiklasJavier/SOT [--accept-flake-config]` — install the prebuilt native `sot` from the flake + cache (download-only).
+- `nix profile install nixpkgs#<pkg>` — provision a system tool (git/ansible/…) via `NixService.install` / `NixToolProvisioner`.
+- `nix profile upgrade --profile {stateRoot}/profiles/<id> <name>` — app update for a nix-managed app.
+- `nix profile upgrade --profile $SOT_HOME/state/profile --all` — reconcile toolchain after declared tool set changes.
+- `nix profile upgrade sot` — CLI self-update (replaces GitHub-Release re-download).
+- `nix profile remove --profile {stateRoot}/profiles/<id> <name>` — app remove (then unlink `bin/*`, rm profile dir).
+- `nix profile list [--profile …] --json` — read installed locked rev + store-path version for the update monitor.
+- `nix flake metadata <flakeRef> --json` — `NixVersionResolver` reads `.locked.rev` / `.lastModified` for upstream comparison.
+- `nix eval --raw github:NixOS/nixpkgs/<rev>#<attr>.version` — resolve upstream version of a nixpkgs attr.
+- `nix build <flakeRef>#<attr> --out-link {stateRoot}/apps/<id>/result` — `mode: build` alternative to profile install.
+- `nix build .#default` — build/realize the native derivation locally (CI + contributors).
+- `nix build <ref> --no-link --print-out-paths` — `NixService.build`.
+- `nix flake update $SOT_HOME/toolchain` — gated bump of the pinned nixpkgs (updates `flake.lock`).
+- `nix run github:NiklasJavier/SOT -- <args>` — run without installing (`apps.default`).
+- `nix config show --json` — `NixService.currentConfig`.
+- `curl -fsSL https://install.determinate.systems/nix | sh -s -- install --no-confirm` — Determinate multi-user daemon install (flakes on).
+
+### (b) New / changed `sot` CLI commands
+
+- `sot bootstrap` — `NixBootstrapTask`: ensure nix present → ensure SOT cache substituter → reconcile toolchain.
+- `sot doctor` — `NixDoctorCheck`: nix/flakes/cache/tools/docker-daemon status (WSL-aware via `WslEnvironment`).
+- `sot app install <id>` / `sot app update <id>` / `sot app remove <id>` — now run on the nix substrate (profile install/upgrade/remove).
+- `sot app outdated` — update monitor over nix flake metadata / nix eval fan-out.
+- `sot app` — interactive App-Selektor (through the Windows shim on Windows; ConPTY under Windows Terminal).
+- `sot self-update` — `SelfUpdateCommand` → `NixService.profileUpgrade` (`nix profile upgrade sot`).
+- `sot toolchain update` — gated `nix flake update` of the pinned nixpkgs.
+- `sot nix status` — inspect the SOT profile.
+- `sot nix gc` — garbage-collect old profile generations.
+
+### (c) Install one-liners per platform
+
+- **Linux / macOS:** `curl -fsSL https://jklein.de/cli/install.sh | bash` (Nix + cache + `nix profile install github:NiklasJavier/SOT`).
+- **Any (no install):** `nix run github:NiklasJavier/SOT -- app list`.
+- **Any (explicit):** `nix profile install github:NiklasJavier/SOT --accept-flake-config`.
+- **Windows:** `irm https://<host>/cli/install.ps1 | iex` (elevates → WSL2 → NixOS-WSL → runs Linux `install.sh` inside → drops shim).
+- **Cache-only client config:** `cachix use sot`.
+
+### (d) justfile / gradle / release additions
+
+- `just install-local` → `nix profile install .#default` — install the local flake (dev).
+- `just apps-add <id>` → `sot app install <id>` (nix substrate).
+- `just tools-ensure docker` → `NixToolProvisioner` shared system profile.
+- `just nix-bootstrap` — wrapper over ensure-nix.
+- `just toolchain-sync` — wrapper over reconcile.
+- `just release TAG` → `gradlew jreleaserFullRelease` + regen flake asset hashes + cachix push.
+- `just win-build` — cross-compile `sot.exe` shim + assemble `dist/windows/` assets for `/cli/`.
+- `just win-tarball` — build the NixOS-WSL `nixos.wsl` rootfs from the flake + emit `nixos.wsl` + `nixos.wsl.sha256`.
+- `just win-publish` — upload `install.ps1`, `sot.exe`/`sot.cmd`, `nixos.wsl`(+sha256), `manifest.json` to owner `/cli/`.
+- `nix develop` — enter devShell (jdk21 + gradle + just + mandrel) for hermetic contributor builds.
+- **CI `release.yml`:** build native per system → JReleaser publish assets → compute asset SHA-256 → update `flake.nix` asset hashes → `nix build .#default` on each runner → `cachix-action@v17` push signed store paths.
+- **Windows raw WSL commands** (invoked by `install.ps1` / shim): `wsl --install --no-distribution`; `wsl --install --from-file nixos.wsl` (≥2.4.4) / `wsl --import NixOS <dir> nixos.wsl --version 2`; `wsl -d NixOS -u root -- bash -lc 'curl -fsSL https://<host>/cli/install.sh | bash'`; `wsl -d NixOS -e sot <args>`.
+
+---
+
+## 4. Consolidated Decisions (question → recommendation)
+
+**AGREED across areas:**
+
+1. **Source build (gradle2nix) vs fetchurl-wrapper for the SOT flake?** → **fetchurl-wrapper for v1** (autoPatchelfHook on Linux, plain install on darwin). The cache means users download prebuilt either way, so a hermetic in-sandbox GraalVM/Mandrel build buys no UX gain and is brittle across 4 systems. Keep gradle2nix as a documented future `packages.sot-src` track. *(cli-as-flake AND nix-substrate agree.)*
+2. **How does self-update work now?** → `nix profile upgrade sot` — atomic, rollback-able (`nix profile rollback`), no re-exec/ATOMIC_MOVE. Retire `BinaryUpdater`'s GitHub-Release download; `SelfUpdateCommand` shells `NixService.profileUpgrade`. On Windows it stays entirely Linux-side inside WSL; the thin shim is version-agnostic. *(cli-as-flake + windows-wsl agree.)*
+3. **Multi-user (daemon) vs single-user Nix?** → **Multi-user daemon** (Determinate default) on Linux/macOS/WSL; fall back to single-user only where systemd/root unavailable; skip nix install entirely inside NixOS/NixOS-WSL. *(nix-substrate; consistent with all.)*
+4. **Flake reference?** → `github:NiklasJavier/SOT` as canonical (git host is source of truth, works with `nix profile upgrade`). `install.sh` served from owner `/cli/` but internally targets the github flake; a tarball flake on owner host is a fallback.
+5. **Does JReleaser + sha256 + cosign survive?** → Yes — JReleaser still publishes per-platform assets (the fetchurl source); cosign stays as defense-in-depth; Nix per-asset hash pinning + cache signing key become the primary integrity gate. The loose `.sha256` sidecar consumption in install.sh is dropped; asset hashes live in `flake.nix`, regenerated by CI.
+6. **Which Linux distro backs the Windows path — Ubuntu+Nix vs NixOS-WSL?** → **NixOS-WSL** (the 100%-Nix mandate means the Linux env should itself be declaratively Nix; `sot` installs identically to native Linux, zero Windows-specific install logic). *(windows-wsl; no area disagrees.)*
+7. **Cross-platform SOT flake systems** → enumerate `x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin`; macOS promoted to first-class native. Resolves D19 (was macOS JVM-only, Windows absent).
+
+**⚠️ FLAGGED DISAGREEMENTS between areas:**
+
+8. **⚠️ Binary cache: Cachix (managed) vs self-hosted attic?** — **DISAGREEMENT.**
+   - `cli-as-flake` → **Cachix for v1** (`sot.cachix.org`, `cachix-action@v17`, zero-ops); attic on `cache.jklein.de` as sovereignty option.
+   - `nix-substrate` → **Self-hosted attic default** (`sot.jklein.de/cache`, to keep everything on owner infra per the `/cli/` host requirement); Cachix as zero-ops quick-start.
+   - *Same substituter+trusted-key mechanism either way — swap two nix.conf lines. Needs an owner call on which is v1 default. (windows-wsl tarball references a generic `<cache>.cachix.org`.)*
+
+9. **⚠️ Per-app Nix profiles vs one shared profile** — **PARTIAL TENSION (different scopes, but two profile models coexist).**
+   - `app-install` → **Per-app profiles** at `{stateRoot}/profiles/<appId>` for APPS (independent generations/rollback, isolated failure, clean removal; `bin/*` symlinked onto one sot-managed PATH dir). A shared `system` profile is used ONLY for system tools via `NixToolProvisioner` (installs `nixpkgs#docker` etc. individually).
+   - `nix-substrate` → **One dedicated profile** `$SOT_HOME/state/profile` holding ALL tools as a single `buildEnv` `toolchain` entry (generated flake + committed `flake.lock`), via `NixToolchainReconciler`. Explicitly rejects per-tool `nix profile install nixpkgs#x` (unpinned, clutters profile) except as a `--simple` fallback.
+   - *Reconcile: apps = per-app profiles (both compatible); TOOLS have TWO competing mechanisms — `NixToolProvisioner`'s shared `system` profile with individual installs vs `ToolchainManager`'s single buildEnv toolchain profile. Pick the buildEnv/reconciler model (reproducible, pinned) and have `NixToolProvisioner` route through it.*
+
+10. **⚠️ terraform vs opentofu default** — **RESOLVED-ish, but examples diverge.** `nix-substrate` decides: map `terraform` → **opentofu** by default in `NixPackageCatalog` (avoids BSL + unfree flag), overridable via `SotConfig.tools`. `app-install`'s `app.yml` example still uses `attr: terraform` illustratively — align the example to the opentofu default.
+
+11. **How does a NIX (nixpkgs attr) app get pinned/updated within a constraint?** → Pin the nixpkgs input to a channel/rev in `source.nixpkgs` (or global default). EXACT pin ⇒ frozen rev in `installed.yml`; RANGE (`version.constraint`) ⇒ move the nixpkgs rev/branch only while resolved attr `.version` stays in range; fall back to input-rev comparison when `.version` isn't SemVer.
+
+12. **`nix profile install` vs `nix build`+symlink as default install mechanism?** → Default `nix profile install` (generation history, upgrade/rollback, matches self-update story). Offer `mode: build` (`nix build --out-link`) as opt-in for apps needing only a stable store-path result.
+
+13. **Keep GITHUB_RELEASE_BINARY / DOCKER_IMAGE source+version types?** → **Drop GITHUB_RELEASE_BINARY** as an app source (fold owner apps into `NIX_FLAKE`). KEEP `DOCKER_IMAGE` version strategy for docker-compose apps and `GIT_TAG`/`SCRIPT` for git-repo/script apps. Definitively REMOVE `APT_DEB` (source) and `APT` (version).
+
+14. **One `NixVersionResolver` bean for both NIX and NIX_FLAKE, or two?** → One implementation with two registrations (small `StrategySet` or two 1-line subclasses) so `UpdateMonitorService`'s `Map<UpdateStrategy,VersionResolver>` stays exact while `nix flake metadata` / `nix eval` logic is shared.
+
+15. **SOT-managed generated flake (buildEnv) vs per-tool `nix profile install nixpkgs#x`?** → Generated flake `buildEnv` in `$SOT_HOME/toolchain`, one profile entry; atomic, one PATH entry, committed `flake.lock` = reproducibility. Per-tool installs only as a `--simple` fallback. *(Feeds decision #9.)*
+
+16. **Mutate the user default nix profile or a dedicated one?** → **Dedicated** profile `$SOT_HOME/state/profile`; never clobber the user default; SOT owns and can wipe its own.
+
+17. **docker daemon (not a profile package)?** → Install docker CLI as `PROFILE_PKG`; treat the daemon as `SYSTEM_SERVICE` — doctor delegates (NixOS-WSL `virtualisation.docker.enable`, macOS colima/Docker Desktop). Never profile-install a running daemon.
+
+18. **macOS secret handling without tmpfs?** → On darwin `TransientPasswordFile` falls back to `mkstemp` 0600 under encrypted APFS `$TMPDIR` (no tmpfs on macOS); guard perms via `PosixGuards`. Resolves D19.
+
+19. **`sot.cmd` vs compiled `sot.exe` as the Windows PATH shim?** → Ship code-signed `sot.exe` as primary (faithful argv vector, inherited ConPTY stdio, exact exit code); `sot.cmd` as zero-dependency fallback for policy/SmartScreen-blocked environments.
+
+20. **Pre-bake sot into the `nixos.wsl` tarball, or install via `install.sh` after import?** → Minimal NixOS-WSL tarball + `install.sh` from the binary cache (single source of truth with Linux/macOS, always-current sot). Optionally publish a batteries-included tarball for offline/air-gapped.
+
+21. **`wsl --install --from-file` vs `wsl --import`?** → Prefer `--from-file` (WSL ≥2.4.4, cleaner registration); fall back to `--import NixOS <dir> nixos.wsl --version 2` on older WSL, gated by a version probe.
+
+22. **How to survive the WSL-feature-enablement reboot?** → `HKCU\...\RunOnce` entry re-invoking `irm .../install.ps1 | iex` with `SOT_RESUME=B`; every stage idempotent so a repeated run is safe.
+
+23. **WSL2 networking mode for services (docker etc.)?** → Default NAT + `localhostForwarding=true`; recommend mirrored networking on Win11 22H2+ for inbound/parity. Document, don't hard-require.
+
+---
+
+## 5. Native-Image / Reproducibility / Risks
+
+### 5.1 GraalVM-native-in-Nix build concern (gradle2nix vs fetchurl-wrapper)
+
+Both `cli-as-flake` and `nix-substrate` recommend the **fetchurl-wrapper** flake around the CI-built GraalVM/Mandrel native binary as the v1 default, NOT a from-source gradle2nix build. Rationale: a reproducible from-source `native-image` build inside the pure Nix sandbox is heavy (large builder image, offline dep-vendoring via a fixed-output derivation, slow, brittle across the 4 systems), and — because the binary cache means users download the prebuilt closure regardless — it buys **no UX benefit**. The CI native binary is the tested source of truth. The wrapper uses `fetchurl` + `autoPatchelfHook` on Linux (mostly-static glibc binary from D1, `buildInputs = [stdenv.cc.cc.lib zlib]` kept minimal) and plain `install -Dm755` on darwin (Mach-O, no patchelf). gradle2nix is documented as a future, audited `packages.sot-src` hermetic-source-build track behind the default.
+
+### 5.2 Reproducibility notes
+
+- **App/CLI pinning:** flake `flake.lock` governs transitive pins for `NIX_FLAKE`; nixpkgs input pinned by channel/rev for `NIX`; EXACT pin ⇒ frozen locked rev in `installed.yml`.
+- **Toolchain:** SOT-generated `$SOT_HOME/toolchain/flake.nix` with a SOT-pinned nixpkgs input + **committed `flake.lock`** = full reproducibility; one atomic `buildEnv` entry. Updates only on demand via gated `sot toolchain update` (`nix flake update`).
+- **Asset integrity:** `flake.nix` asset SHA-256 hashes regenerated by CI in the same release job; release fails if `nix build .#default` mismatches. Cache signing key + per-asset hash pinning are the primary integrity gate (cosign kept as defense-in-depth).
+- **Version comparison correctness:** flakes compared by locked rev / `lastModified` equality (never invented ordering); nixpkgs attrs by hand-rolled `SemVer` only when parseable, else input-rev equality + report `UNKNOWN`.
+
+### 5.3 Top 7 Risks (ranked, deduplicated across areas)
+
+1. **Binary-cache miss forces compile-from-source (huge, slow) — undermines the whole download-only value prop and breaks first-run UX on every platform.** *(app-install, nix-substrate, cli-as-flake all raise it.)* → Mandatory substituter + trusted-public-key configured in nix.conf BEFORE first install; CI pushes every catalog flake app + pinned nixpkgs closure + native CLI + toolchain to the owner Cachix/attic cache; surface a "building from source, no cache hit" warning in `ProgressReporter`; doctor flags an unreachable cache.
+2. **The mostly-static/musl native binary cannot `fork/exec` — yet EVERY `NixService` call shells out to `nix`; and `autoPatchelfHook` can mis-patch the glibc binary, breaking fork/exec of external tools (D1).** *(nix-substrate + cli-as-flake.)* → Keep the D1 mostly-static **glibc** decision (not musl); keep `buildInputs` minimal (`cc.cc.lib`+`zlib`); the native-image CI gate must prove the binary actually execs `nix --version` / `git --version` from the store path on every system before cachix push.
+3. **A non-trusted-user cannot honor `extra-substituters`/keys in user nix.conf → silently falls back to compiling from source (needs Mandrel).** *(cli-as-flake.)* → Determinate installer adds the installing user as a trusted-user; `install.sh` verifies and, on multi-user daemon installs, offers to write the system `/etc/nix/nix.conf`; flake `nixConfig` + `--accept-flake-config` is a second path.
+4. **`nix` binary absent / flakes not enabled → every nix strategy fails.** *(app-install.)* → `install.sh` runs the Determinate nix-installer (flakes on by default) before first `sot` run; `ToolPreflight`/doctor verify `nix --version` + experimental-features, emitting a single actionable remediation instead of raw nix errors.
+5. **`nix flake metadata` / `nix eval` fan-out over all installed apps is slow + network-bound (stalls `sot app outdated`); and non-SemVer nixpkgs `.version` strings / rev-less flake refs cause wrong ordering / "always outdated".** *(app-install ×2.)* → Keep the virtual-thread `StructuredTaskScope` fan-out + `VersionCache` (TTL / serve-stale, keyed by flakeRef); use the denormalized rev in the catalog index; per-app failure ⇒ `UNKNOWN`, never abort; compare flakes by locked rev equality, nixpkgs by SemVer only when parseable.
+6. **Supply-chain / MITM: the Determinate `curl | sh` installer pipe and the `nixos.wsl` tarball download.** *(nix-substrate + windows-wsl.)* → Pin the installer version + verify its checksum in `install.sh`; https-only; publish `nixos.wsl.sha256` + `manifest.json` on the owner host and hard-fail `install.ps1` on checksum mismatch.
+7. **Legacy migration breakage: existing manifests using `source.type: apt-deb` (+ `version.strategy: apt`), and old curl-binary `/usr/local/bin/sot` users who can't `nix profile upgrade`.** *(nix-substrate + cli-as-flake.)* → Legacy migration reader rewrites `apt-deb`→`nix` and `apt`→`nix` with a tool→nixpkgs-attr guess flagged for owner review (D20); Phase-9 doctor detects a legacy `/usr/local/bin/sot` and offers a one-shot `nix profile install` reinstall; `SelfUpdateCommand` errors clearly if not nix-managed.
+
+### 5.4 Remaining risks (deduplicated)
+
+- **fetchurl asset-hash drift** from JReleaser output → flake build fails or points at the wrong asset → CI regenerates hashes from just-published assets in the same job; asset name schema single-sourced. *(cli-as-flake.)*
+- **Cachix outage / key rotation** blocks installs / breaks trust → substituters degrade to source build; maintain an attic mirror as extra-substituter; key rotation via append (old key kept during overlap). *(cli-as-flake.)*
+- **macOS Gatekeeper / quarantine / unsigned Mach-O** → nix store execution bypasses quarantine for daemon-fetched paths; `codesign --sign -` (ad-hoc) in CI; document `xattr -d com.apple.quarantine` fallback. *(cli-as-flake.)*
+- **docker daemon can't be a user-profile package on non-NixOS** → split `PROFILE_PKG` vs `SYSTEM_SERVICE`; doctor gives platform-specific daemon guidance. *(nix-substrate + app-install + windows-wsl.)*
+- **Per-app profiles multiply /nix/store closures + PATH symlink collisions** → shared-store dedup; resolve `bin/*` conflicts by app priority + warn; `nix store gc` hooked into remove. *(app-install.)*
+- **Pinned `flake.lock` drifts from upstream security fixes** → gated `sot toolchain update`; UpdateMonitor surfaces a stale-nixpkgs signal. *(nix-substrate.)*
+- **macOS Nix install needs /nix volume + sudo; NixOS-WSL bootstrap differs** → `probe().insideNixOS` + `system` branch the flow; Determinate macOS volume handling; doctor verifies `daemonMode`. *(nix-substrate.)*
+- **WSL2 unavailable** (Windows Home older builds, virtualization off, nested VM) → preflight build ≥19041 + virtualization; actionable message; offline manual `Enable-WindowsOptionalFeature` path. *(windows-wsl.)*
+- **RunOnce reboot resume is fragile** → every stage idempotent (`wsl -l -q` scan, checksum-gated download, PATH-contains guard). *(windows-wsl.)*
+- **SmartScreen / AV blocks `irm | iex` or unsigned `sot.exe`** → code-sign `install.ps1` + `sot.exe`; ship `sot.cmd` fallback; offline `-LocalAssets` install. *(windows-wsl.)*
+- **Interactive App-Selektor TTY misbehaves in legacy conhost** → line-oriented selector degrades to `list` when `System.console()==null`; recommend Windows Terminal. *(windows-wsl.)*
+- **docker/systemd not running in WSL** → NixOS-WSL tarball ships `systemd.enable` + `virtualisation.docker.enable`; `sot doctor` checks. *(windows-wsl.)*
+- **Windows-path args through the shim break inside Linux** (`C:\` vs `/mnt/c`) → keep the shim thin (verbatim argv); document `wslpath`; warn on slow `/mnt/c`. *(windows-wsl.)*
+- **Distro-name collision** / pre-existing `NixOS` registration → detect via `wsl -l -q`, skip re-import; versioned name override; never overwrite without a reinstall flag. *(windows-wsl.)*
+
+### 5.5 Final enum values (apt-deb removed, nix/nix-flake added)
+
+**`AppSourceType`** (source types):
+```
+NIX, NIX_FLAKE, GIT_REPO, DOCKER_COMPOSE, SCRIPT
+```
+- ADDED: `NIX` (nixpkgs attribute), `NIX_FLAKE` (flake installable ref).
+- KEPT: `GIT_REPO`, `DOCKER_COMPOSE`, `SCRIPT`.
+- REMOVED: `APT_DEB` (definitively), and `GITHUB_RELEASE_BINARY` dropped as an app source (owner apps fold into `NIX_FLAKE`).
+
+**`UpdateStrategy`** (version/update monitoring):
+```
+NIX, NIX_FLAKE, GITHUB_RELEASE, GIT_TAG, DOCKER_IMAGE, STATIC, SCRIPT
+```
+- ADDED: `NIX`, `NIX_FLAKE`.
+- REMOVED: `APT`.
+- KEPT: `GITHUB_RELEASE`, `GIT_TAG`, `DOCKER_IMAGE`, `STATIC`, `SCRIPT`.
+
+**Supporting enum:** `NixPkgKind { PROFILE_PKG, SYSTEM_SERVICE }` — splits profile-installable tools (docker CLI) from platform-managed daemons (docker daemon).

--- a/docs/java-quarkus-rewrite-plan.md
+++ b/docs/java-quarkus-rewrite-plan.md
@@ -1,282 +1,394 @@
-# SOT — Rewrite-Plan: Bash → natives Java-CLI (Quarkus + GraalVM)
+# SOT — Rewrite-Plan: Bash → natives Java-CLI (Quarkus + GraalVM), als dynamischer App-Manager
 
-> **Richtungsentscheidung:** SOT wird **komplett** von Bash auf ein **natives Java-CLI** umgebaut — **Java 21 + Quarkus 3.37+ + Picocli + GraalVM/Mandrel native-image**, als ein einzelnes selbstständiges Binary pro Plattform. Kein In-place-Bash-Refactoring mehr (der alte [`refactoring-plan.md`](./refactoring-plan.md) ist damit obsolet).
+> **Was gebaut wird:** SOT wird komplett von Bash auf ein **natives Java-CLI** umgebaut — **Java 21 · Quarkus 3.37+ · Picocli · GraalVM/Mandrel native-image**, ein selbstständiges Binary pro Plattform, **gebaut mit Gradle**, mit einem **Justfile** als Entwickler-Frontend.
 >
-> **Grundlage:** Die bestehende Fähigkeits-/Befund-Inventur ([`refactoring-findings.md`](./refactoring-findings.md), 88 Befunde) ist die **funktionale Spezifikation** — jede heute vorhandene Fähigkeit muss im Java-CLI erhalten bleiben, und jeder der 88 Bugs muss im Neubau entweder **strukturell verschwinden** oder **bewusst gehärtet** werden. Der Ziel-Entwurf wurde von 9 Architektur-Agenten je Schicht entworfen; Quarkus/Picocli-Fakten sind gegen die aktuelle Doku (Context7) geprüft.
+> **Wozu:** SOT ist ein **dynamischer App-Manager für die eigene Umgebung** — ein CLI-**App-Selektor**, mit dem der Owner seine **eigenen Anwendungen** installiert, aktualisiert und **überwacht** (welche App ist veraltet), plattform-/quellenübergreifend, **ohne den Toolneubau** (neue App = neue Manifest-Datei im Katalog).
+>
+> **Grundlagen-Doku (Evidenz):** [`refactoring-findings.md`](./refactoring-findings.md) (88 Ist-Befunde = funktionale Spec), [`java-quarkus-design-brief.md`](./java-quarkus-design-brief.md) (Schicht-Entwurf), [`java-quarkus-appmanager-brief.md`](./java-quarkus-appmanager-brief.md) (App-Manager + Delivery). Der alte Bash-in-place-Plan [`refactoring-plan.md`](./refactoring-plan.md) ist **superseded**.
 
 ---
 
-## 1. Zielbild in einem Satz
+## 1. Die zwei Kern-Anforderungen (und wie der Plan sie erfüllt)
 
-Aus ~10 000 Zeilen dynamischem Bash wird **eine typisierte, DI-verdrahtete Java-Anwendung**, die zu **einem nativen Binary** kompiliert (schneller Start, kein JVM/Runtime nötig) und die **externen Tools (ansible, ansible-vault, terraform, git, docker) weiterhin per Prozessaufruf orchestriert**. Die Ansible-Playbooks, Docker- und Vault-Templates werden **nicht** zu Java — sie bleiben deklarative Assets, die als Classpath-Ressourcen eingebettet und zur Laufzeit von Java extrahiert und aufgerufen werden.
+| # | Anforderung | Umsetzung |
+|---|---|---|
+| **A** | **Ein-Befehl-Installation via GitHub-URL** auf Debian/Linux — Nutzer geben genau **einen** Bash-Befehl ein. | `curl -fsSL https://raw.githubusercontent.com/NiklasJavier/SOT/<ref>/install.sh \| bash` lädt das passende **vorgebaute native Binary** aus GitHub Releases, verifiziert (SHA-256 + cosign) und legt `sot` auf den PATH. Kein JVM, kein Build beim Nutzer. → §3 |
+| **B** | **Dynamischer App-Manager**: App-Selektor im CLI, eigene Anwendungen installieren/updaten **über alle Apps hinweg**, mit **Update-Überwachung**, „tief dynamisch". | Apps sind **deklarative Manifeste** (`app.yml`) aus einem **konfigurierbaren Katalog-Repo**, orchestriert von einem festen Satz **Install-Strategien**. Neue App = Manifest hinzufügen, **kein Rebuild**. Ein `UpdateMonitor` prüft quellenübergreifend „veraltet?". → §2 |
 
-**Warum das die 88 Bugs erschlägt:** Die überwältigende Mehrheit der Befunde sind **Artefakte des Bash-Modells** — String-Dispatch, `source`-Laden, Wort-Splitting, positionale argv-Übergabe, YAML-Parsing per `cut`/`xargs`, CI per Verzeichnis-Glob. In einem **typisierten, CDI-verdrahteten Single-Binary-Design sind diese Bug-Klassen per Konstruktion unmöglich** (siehe Mapping §5). Ein kleiner Rest bleibt echtes Engineering (native-image-Constraints, Secret-Handling, Linking) — der wird in §7/§9 explizit adressiert.
-
-**Was ausdrücklich NICHT verschwindet:** Die **Ansible-Modul-Bugs (Befund-Thema L, 10 Stück** — UFW `policy: allow`, `readVaultParameter`-Rollenname, `/etc/hosts`-Regex, Vault-Passwort-Lifecycle, OS-Abstraktion …) leben in den Playbooks weiter, weil Ansible bleibt. Sie müssen **bei der Portierung der YAML-Assets aktiv gefixt** werden — der Java-Umbau löst sie nicht auf. (Eigener Task in Phase 6.)
+**Der architektonische Kniff (löst „tief dynamisch" vs. GraalVM-Closed-World):** GraalVM native-image ist **Closed-World** — kein Laden neuer Java-Klassen zur Laufzeit. „Tief dynamisch" heißt daher **nicht** „Java-Plugins nachladen", sondern: die **Menge der Strategien** (git/docker-compose/release-binary/deb/script) ist fest **einkompiliert**; **welche Apps existieren** und ihre gesamte Konfiguration sind **100 % Laufzeit-Daten** (Manifeste aus git/HTTP). So ist das System voll dynamisch **ohne** die Closed-World-Annahme zu verletzen.
 
 ---
 
-## 2. Ziel-Stack
+## 2. Kern-Zweck: Der dynamische App-Manager
+
+### 2.1 Zwei getrennte Achsen (das zentrale Designprinzip)
+
+Bash vermischte „**woher** kommt eine App-Definition" mit „**wie** wird sie installiert". Java trennt sie:
+
+- **`CatalogSource` — WOHER (100 % Laufzeit-Daten).** Ein konfigurierbarer Satz Kataloge: `git` (dein Katalog-Repo), `http-index` (ein Index-URL), `bundled` (eingebettete Default-Apps). Zur Laufzeit gefetcht, nach `priority` gemerged. Neue App = `app.yml` in den Katalog legen.
+- **`InstallStrategy` — WIE (fest einkompiliert).** Fünf CDI-Beans hinter **einem** Interface: `git-repo`, `docker-compose`, `github-release-binary`, `apt-deb`, `script`. Neue Strategie = Bean hinzufügen (Rebuild). Jede delegiert an die geteilte `ProcessRunner`/`GitService`/`GitHubReleaseClient` — kein Neuimplementieren von exec.
+
+Das **subsumiert die alte Extension/Plugin-Schicht**: eine „Extension" (AAT/TID) ist jetzt einfach eine App mit einem `runner:`-Block. `CapabilityService`→`AppService`, `CapabilityStateStore`→`InstalledAppStore`, `module.yml`→`app.yml`. Ein Vokabular.
+
+### 2.2 Das App-Manifest (`app.yml`) — die deklarative Einheit
+
+```yaml
+apiVersion: sot.dev/v1
+kind: App
+id: grafana                     # katalog-eindeutige, stabile ID
+name: Grafana
+description: Monitoring dashboards
+category: observability
+labels: [monitoring, ui]
+source:                         # WIE installieren → wählt die InstallStrategy
+  type: docker-compose          # git-repo | docker-compose | github-release-binary | apt-deb | script
+  repoUrl: https://github.com/owner/grafana-stack
+  ref: v10.4.0
+  composeFile: docker-compose.yml
+version:                        # WIE „neueste Version" bestimmen → wählt den VersionResolver
+  strategy: docker-image        # github-release | git-tag | docker-image | apt | static | script
+  constraint: '>=10.0.0 <11.0.0'
+  tagPattern: '^v(\d+\.\d+\.\d+)$'
+requires:                       # topologisch vor der Installation aufgelöst
+  tools: [docker]
+  apps:  [prometheus]
+  os:    [debian, ubuntu]
+install:
+  path: '{appsRoot}/grafana'    # via SotPaths getemplatet
+  env:  { GF_PORT: '3000' }
+  hooks: { postInstall: scripts/post.sh }
+runner:                         # OPTIONAL — vorhanden ⇒ App ist eine AAT/TID-artige Ansible-Extension
+  playbooks: [site.yml]
+```
+
+Ein Katalog listet seine Apps in einer `index.yml` (`id → manifest-Pfad + denormalisierte Version` für schnelles Listing). Der installierte Zustand lebt getrennt in `installed.yml` (0600, atomar geschrieben): installierte Version, Quelle, Pfad, Pin-Status, Checksum.
+
+### 2.3 Die eine Install-Strategie-Schnittstelle
+
+```java
+public interface InstallStrategy {
+  AppSourceType type();                                      // GIT_REPO | DOCKER_COMPOSE | GITHUB_RELEASE_BINARY | APT_DEB | SCRIPT
+  ResolvedSource resolve(AppManifest m, InstallContext ctx); // bindet+validiert source.options (raw JsonNode → typisierte Slice)
+  InstallOutcome install(ResolvedSource s, InstallContext ctx);
+  InstallOutcome update (ResolvedSource s, InstalledApp cur, InstallContext ctx);
+  void           remove (InstalledApp cur, InstallContext ctx);
+}
+// Verdrahtung: @All List<InstallStrategy> → Map<AppSourceType,InstallStrategy> zur BUILD-Zeit (Closed-World)
+```
+
+`AppService` ist der einzige Lifecycle-Owner: `list/search/info/install(topo-resolve requires.apps)/update/upgradeAll/remove/pin/unpin/outdated`. Er wählt die Strategie aus der `Map<AppSourceType,…>` und persistiert über `InstalledAppStore`.
+
+### 2.4 Update-Überwachung (das „überwacht, ob geupdated werden kann")
+
+Getrennte Achse `de.jklein.sot.app.update`: ein **`VersionResolver`-SPI** je Quelltyp (`UpdateStrategy` = `GITHUB_RELEASE | GIT_TAG | DOCKER_IMAGE | APT | STATIC | SCRIPT`), ebenfalls `@All`-injiziert. `InstallStrategy.update()` **ruft** den passenden `VersionResolver` — kein doppeltes „latest"-Design.
+
+```java
+interface VersionResolver { UpdateStrategy strategy(); ResolvedVersion resolveLatest(VersionQuery q, ResolverContext ctx); }
+record ResolvedVersion(Optional<Version> latest, String rawLatest, Optional<String> digest, Instant at, CacheDisposition cache) {}
+enum UpdateStatus { UP_TO_DATE, UPDATE_AVAILABLE, PINNED, UNKNOWN, NOT_INSTALLED }
+record OutdatedReport(Instant generatedAt, List<AppUpdateReport> apps, int upToDate, int updatable, int pinned, int unknown) {}
+```
+
+- **`UpdateMonitorService.checkAll()`** fächert `resolveLatest()` über **Virtual Threads** (StructuredTaskScope + Semaphore) über **alle installierten Apps**, vergleicht eine **hand-gerollte, native-sichere `SemVer`** gegen die installierte Version unter Berücksichtigung von `constraint` + Pin, und faltet in einen `OutdatedReport`. Fehler je App → `UNKNOWN`, nie Abbruch.
+- **Kein Daemon.** Das Binary ist kurzlebig (schneller Start ist der Punkt). `sot bootstrap` installiert einen **systemd-Timer** (Cron-Fallback), der `sot app check --quiet --notify` tickt; der Tick schreibt `last-check.json`, `UpdateNotifier` meldet nur bei **Zustandsänderung**. `sot app status`/`outdated` lesen den Cache für sofortige Offline-Anzeige (Netz nur bei `--refresh`).
+- **Robust gegen die Realität:** ETag-Conditional-GETs + TTL-Cache + Serve-Stale bei Rate-Limit; nicht-semver-Tags (calver/sha/`:latest`) werden per **Gleichheit/Digest** verglichen (keine erfundene Ordnung); Pins (`installed.yml`, nicht Manifest): EXACT→eingefroren, RANGE→Update nur innerhalb der Range.
+
+### 2.5 Der App-Selektor (die Bedien-Oberfläche)
+
+Ein Picocli-Parent `sot app` (Aliase `apps`, `a`) — **die eine Vokabel** für das, was früher extensions/plugins/capabilities war. Bare auf einem TTY startet der interaktive Selektor; bare in einer Pipe druckt `list` (blockiert nie).
+
+```
+sot app                      # TTY → interaktiver Selektor · Pipe → list
+sot app browse | select      # Selektor explizit (für Skripte/Tests)
+sot app list [--json] [--outdated] [--role runner]      (alias ls)
+sot app search <query>       # fuzzy über alle Kataloge
+sot app info <id> [--json]   # Manifest, Quelle, installiert/verfügbar, Dep-Baum
+sot app install <id>[@version]… [--yes] [--dry-run]     (alias add, i)
+sot app update <id> | --all [--yes]                     (alias up)   # überspringt Pins
+sot app outdated [--json] [--cached]                    (alias stale) # ← Monitoring-Fläche
+sot app status [<id>]        # Dashboard: up-to-date/outdated/pinned/unknown/broken
+sot app check [--quiet] [--notify] [--refresh]          # Timer-/Refresh-Einstieg
+sot app remove <id> [--yes]                             (alias rm, uninstall)
+sot app pin <id>[@version|range] | sot app unpin <id>
+sot app catalog list | add <url> | remove <id> | refresh   (alias: sot app refresh)
+sot ex …                     # lebendiger Alias: Filter role=runner (AAT/TID-Muscle-Memory)
+sot extensions… | sot plugins…   # deprecated Forwarder → app list/install (mit Hinweis)
+```
+
+Der `AppSelector` ist bewusst **zeilenorientiert** (nummerierte Tabelle via `ConsoleService` + `BufferedReader`-Loop: Zahlen togglen, `/query` fuzzy, `a` alle, `i` install, `u` update, Enter bestätigen, `q` quit). **Kein JLine/ncurses/`stty`** → trivial GraalVM-native-sicher; bei `System.console()==null` verweigert er und fällt auf `list`. Globale Automations-Flags (`--json`, `--yes`, `--no-color`, `--catalog`, `--dry-run`) via `scope=INHERIT`.
+
+---
+
+## 3. Installation: der eine Befehl (Anforderung A)
+
+Zwei Ebenen — **Ebene 1** ist der geforderte Ein-Zeiler, **Ebene 2** hält aktuell:
+
+```bash
+# System-weit (→ /usr/local/bin/sot)
+curl -fsSL https://raw.githubusercontent.com/NiklasJavier/SOT/<ref>/install.sh | sudo bash
+# Per-User (→ ~/.local/bin/sot)
+curl -fsSL https://raw.githubusercontent.com/NiklasJavier/SOT/<ref>/install.sh | bash
+# Version pinnen (umgeht die GitHub-API, deterministisch)
+SOT_VERSION=v1.2.0 curl -fsSL …/install.sh | bash
+```
+
+**`install.sh`** (die **einzige** verbleibende Shell, `set -euo pipefail`, shellcheck-gegated):
+
+```bash
+REPO=NiklasJavier/SOT
+os=$(uname -s | tr A-Z a-z)                          # linux|darwin
+arch=$(uname -m); case $arch in x86_64) arch=amd64;; aarch64|arm64) arch=arm64;; esac
+tag=${SOT_VERSION:-$(curl -fsSL https://api.github.com/repos/$REPO/releases/latest | grep -m1 tag_name | cut -d'"' -f4)}
+base=https://github.com/$REPO/releases/download/$tag ; asset=sot-$os-$arch
+curl -fsSL -o "$tmp/$asset" "$base/$asset" ; curl -fsSL -o "$tmp/$asset.sha256" "$base/$asset.sha256"
+( cd "$tmp" && sha256sum -c "$asset.sha256" )        # Pflicht
+command -v cosign >/dev/null && cosign verify-blob --certificate "$asset.pem" --signature "$asset.sig" \
+  --certificate-identity-regexp 'https://github.com/NiklasJavier/SOT/.+' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com "$tmp/$asset"   # best-effort
+if [ -w /usr/local/bin ] || command -v sudo >/dev/null; then dest=/usr/local/bin; else dest=$HOME/.local/bin; mkdir -p "$dest"; fi
+${SUDO} install -m755 "$tmp/$asset" "$dest/sot"      # dann: Hinweis „sot bootstrap" / PATH
+```
+
+- **Debian-spezifisch:** installiert **nur** das `sot`-Binary (setzt `curl`/`ca-certificates` voraus). Laufzeit-Tools (git/ansible/docker) werden **nicht** still per apt gezogen — `sot doctor`/`sot bootstrap` erkennen/melden sie (D19).
+- **Fallbacks:** `/usr/local/bin` nicht schreibbar → `~/.local/bin` + PATH-Hinweis; darwin → „build-from-source/JVM"-Meldung statt 404 (v1 shippt linux amd64/arm64).
+- **Ebene 2 — `sot self-update`:** in-Binary, nutzt denselben Asset-/Verify-Kontrakt (GitHub-Release → SHA-256 + cosign → Sibling-Temp → `ATOMIC_MOVE` → re-exec).
+- **Asset-Namens-Kontrakt** (single-sourced zwischen JReleaser und `install.sh`): `sot-<os>-<arch>` + `.sha256` + `.sig` + `.pem`, plus `checksums_sha256.txt`, `sbom.syft.json`.
+
+---
+
+## 4. Ziel-Stack
 
 | Ebene | Wahl | Warum |
 |---|---|---|
-| Sprache | **Java 21** (LTS) | Records, sealed types, virtual threads, Pattern Matching — ideal für typisierte Config & Prozess-Draining |
-| Framework | **Quarkus 3.37+** | Auf GraalVM native zugeschnitten; Build-Time-DI (Arc) statt Runtime-Scanning → passt zur Closed-World-Annahme von native-image |
-| CLI | **quarkus-picocli** (Picocli) | Deklarativer Command-Baum, CDI-Injektion in Commands, `AutoComplete.GenerateCompletion` erzeugt bash/zsh-Completion aus dem lebenden Spec |
-| Config | **quarkus-jackson + jackson-dataformat-yaml** | Ein Parser (SnakeYAML-Tokenizer) statt 4 Bash-Parser; typisierte Records; `#`/Quote/Backslash-Korruption unmöglich |
-| Validierung | **quarkus-hibernate-validator** | Bean-Validation auf Config-Records (Port-Range, Namens-Pattern) |
-| Templating | **quarkus-qute** (`@CheckedTemplate`) | Typsicheres Vault-Template ohne Runtime-Reflection (native-freundlich) |
-| Native | **Mandrel/GraalVM CE 21** (`-Dnative`) | Ein Binary je Plattform; `quarkus.native.resources.includes` bettet Assets ein |
-| Build | **Maven** (+ Wrapper) | Quarkus-Primärtoolchain; `mvn …:create -Dextensions='picocli'` |
-| Release | **JReleaser** + GitHub Actions Matrix | Per-Plattform-Binaries, Checksums, SBOM (Syft), Signaturen (cosign) auf GitHub Releases |
-| Verbleibende Shell | **genau ein** `install.sh` | Erkennt OS/Arch, lädt das passende Binary + Checksum, verifiziert, verlinkt |
+| Sprache | **Java 21** (LTS) | Records, sealed types, **virtual threads** (Update-Fan-out), Pattern Matching |
+| Framework | **Quarkus 3.37+** | Für GraalVM native gebaut; Build-Time-DI (Arc) → passt zur Closed-World |
+| CLI | **quarkus-picocli** | Command-Baum, CDI-Injektion, `AutoComplete.GenerateCompletion` (bash/zsh aus dem Spec) |
+| Config/Manifest | **quarkus-jackson + jackson-dataformat-yaml** | Ein Parser; typisierte Records; `#`/Quote/Backslash-Korruption unmöglich |
+| Validierung | **quarkus-hibernate-validator** | Bean-Validation auf Config-/Manifest-Records |
+| Templating | **quarkus-qute** (`@CheckedTemplate`) | Typsicheres Vault-Template, reflection-frei |
+| Native | **Mandrel/GraalVM CE 21** | `-H:+StaticExecutableWithDynamicLibC` (**mostly-static glibc**, nicht musl — s. §7/D1); `resources.includes` bettet Assets ein |
+| **Build** | **Gradle (Groovy DSL)** | *(vom Owner gewählt statt Maven)* Quarkus-Gradle-Plugin; `./gradlew build -Dquarkus.native.enabled=true` |
+| **Dev-Frontend** | **Justfile** (`just`) | *(vom Owner gewählt)* wrappt die Default-Befehle für optimale Ersteinrichtung |
+| Release | **JReleaser (Gradle-Plugin)** + GitHub Actions | Per-Plattform-Binaries, Checksums, SBOM (Syft), cosign auf GitHub Releases |
 
-**Bootstrap-Kommandos (verifiziert):** Projekt: `mvn io.quarkus.platform:quarkus-maven-plugin:3.37.0:create -DprojectGroupId=de.jklein.sot -DprojectArtifactId=sot -Dextensions='picocli,quarkus-jackson'`. Native-Build: `./mvnw install -Dnative` (bzw. `-Dquarkus.native.enabled=true`). Completion: `source <(sot generate-completion)`.
+**Scaffolding & Build (verifiziert gegen aktuelle Quarkus-Docs):**
+```bash
+quarkus create cli de.jklein.sot:sot --gradle -x picocli          # Gradle-Projekt (Groovy DSL)
+./gradlew addExtension --extensions='quarkus-jackson,quarkus-hibernate-validator,quarkus-qute'
+./gradlew quarkusDev                                              # Live-Reload
+./gradlew build                                                   # JVM-Jar + Tests
+./gradlew build -Dquarkus.native.enabled=true                    # natives Binary
+./gradlew check                                                   # Tests + Int-Tests + JaCoCo (CI-Gate)
+./gradlew jreleaserFullRelease                                   # Release (Binaries/Checksums/SBOM/cosign)
+```
+
+Native-Flags gehören in `application.properties` (nicht `build.gradle`):
+```properties
+quarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21
+quarkus.native.container-build=true
+quarkus.native.additional-build-args=-H:+StaticExecutableWithDynamicLibC   # mostly-static glibc (fork/exec-sicher), NICHT --libc=musl
+quarkus.native.resources.includes=apps/**,ansible/**,docker/**,templates/**,config/**,assets/manifest.txt
+quarkus.native.add-all-charsets=true
+```
+
+**Justfile** (Entwickler-Entrypoint, wrappt `./gradlew`):
+```
+setup · dev · build · native · test · lint · fmt · run *ARGS · install-local · release TAG · clean
+apps → sot app list · install <id> → sot app install <id> · check → sot app check --refresh · install-timer
+```
 
 ---
 
-## 3. Ziel-Architektur
-
-### Schichten
-
-```mermaid
-graph TD
-    IN[install.sh + prebuilt native binary] --> CLI
-    subgraph CLI["cli/ — Picocli-Command-Baum (einzige Dispatch-Fläche)"]
-      ROOT["SotCommand @TopCommand + Main @QuarkusMain"]
-    end
-    CLI --> SVC
-    subgraph SVC["Services (CDI-Beans, per Konstruktor injiziert)"]
-      CFG[config/ ConfigService · SotConfig-Records]
-      EXT[extension/ CapabilityService · Provider-Strategien]
-      VLT[vault/ VaultService · Secret-Typ]
-      BOOT[bootstrap/ TaskRunner · SelfUpdate]
-      DOC[doctor/ DoctorService]
-    end
-    SVC --> PROC
-    subgraph PROC["process/ + runner/ — Prozess-Orchestrierung"]
-      PR[ProcessRunner] --> EXTTOOLS
-      GIT[GitService.gitSync]
-    end
-    subgraph RT["runtime/ — Foundation"]
-      YAML[YamlMapperProducer] 
-      PATHS[SotPaths]
-      ASSET[AssetExtractor]
-      REFL[ReflectionConfig]
-    end
-    SVC --> RT
-    PROC --> RT
-    EXTTOOLS["ansible · ansible-vault · terraform · git · docker  (externe Prozesse)"]
-    ASSET -.extrahiert.-> RES["src/main/resources: ansible/ docker/ templates/ modules/"]
-```
+## 5. Ziel-Architektur
 
 ### Package-Baum (`de.jklein.sot.*`)
 
 ```
 de.jklein.sot/
-├── cli/         Picocli-Command-Baum: SotCommand(@TopCommand) · Main(@QuarkusMain) · {Bootstrap,Doctor,Vault,
-│               Runner,Extensions,Plugins,Update,Delete,Interactive}Command · SotVersionProvider · AliasExpander
-│               · AliasCheatSheetRenderer · ConsoleService/ProgressReporter · SotExitCode
-├── config/      SotConfig + {System,Ssh,Logging,Paths,Tools,Ansible,Runner,Vault}Config · ExtensionConfig
-│               · GeneratedValue(enum) · YamlConfigCodec · ConfigMerger · PlaceholderResolver · ConfigValidator
-│               · SecretStore · ConfigService   (EINE kanonische, verschachtelte, typisierte Schema-Quelle)
-├── extension/   CapabilityProvider(interface) · LocalDirectoryProvider · RemoteGitProvider · CapabilityRegistry
-│               · CapabilityService · ExtensionManifest · Capability · CapabilityType · CapabilityStateStore
-│               · ManifestParser · SafeFsRemover   (module=plugin=extension=integration → EIN Konzept)
-├── vault/       Secret(AutoCloseable char[]) · VaultPasswordSource(sealed) · SecretResolver · TransientPasswordFile
-│               · PosixGuards · AnsibleVaultRunner · SecretGenerator · VaultTemplateRenderer · VaultSecrets · VaultService
-├── process/     ProcessRunner(interface)+Impl · ProcessSpec/ProcessResult · ProgressSink/TeeSink · SecretMaterializer
-│               · GitService/GitSyncSpec · WorkspaceManager · ToolPreflight
-├── runner/      AnsiblePlaybookInvocation · AnsibleVaultInvocation · TerraformInvocation · DockerInvocation (typed arg-builder)
-├── bootstrap/   BootstrapTask(interface) + {Preflight,MaterializeAssets,DirectoryLayout,DependencyInstall,VaultReference,
-│               Finalize}Task · TaskRunner · TaskResult/BootstrapReport · InstallLayout · DependencyInstaller
-│               · GitHubReleaseClient · ChecksumVerifier · BinaryUpdater · BuildInfo
+├── cli/         Picocli-Baum: SotCommand(@TopCommand)·Main(@QuarkusMain)·{Bootstrap,Doctor,Vault,Runner,Update,Delete,Interactive}Command
+│               · SotVersionProvider · AliasExpander · ConsoleService/ProgressReporter · SotExitCode
+│   └── app/     App-Selektor-UX: AppCommand(app|apps|a) · AppSelector(zeilenorientiert) · AppTableRenderer · SelectionState
+│               · App{Select,List,Search,Info,Install,Update,Outdated,Status,Remove,Pin,Unpin,Refresh}Command · AppNameCandidates
+│               · ExtensionsCommand/PluginsCommand (deprecated Forwarder)
+├── app/         ★ KERN: AppManifest · SourceSpec · AppSourceType(enum) · InstallStrategy(interface)
+│               · {GitRepo,DockerCompose,GithubReleaseBinary,AptDeb,Script}Strategy · AppCatalog · CatalogSource · CatalogIndex
+│               · InstalledAppStore · InstalledApp · AppService · AppStatus · SemVer · RunnerSpec
+│   └── update/  UpdateMonitorService · VersionResolver(interface) · {GitHubRelease,GitTag,DockerImage,AptPolicy,Script}Resolver
+│               · Version/VersionConstraint · VersionCache · AppUpdateReport/OutdatedReport · UpdateScheduler/UpdateNotifier · InstalledApps(port)
+├── config/      SotConfig + Sektions-Records (System/Ssh/Logging/Paths/Tools/Ansible/Runner/Vault) · CatalogSource-Liste
+│               · YamlConfigCodec · ConfigMerger · PlaceholderResolver · ConfigValidator · SecretStore · ConfigService
+├── vault/       Secret(AutoCloseable) · VaultPasswordSource(sealed) · SecretResolver · TransientPasswordFile · PosixGuards
+│               · AnsibleVaultRunner · SecretGenerator · VaultTemplateRenderer · VaultSecrets · VaultService
+├── process/     ProcessRunner(interface)+Impl · ProcessSpec/Result · ProgressSink/TeeSink · SecretMaterializer
+│               · GitService/GitSyncSpec · GitHubReleaseClient · ChecksumVerifier · WorkspaceManager · ToolPreflight
+├── runner/      AnsiblePlaybookInvocation · AnsibleVaultInvocation · TerraformInvocation · DockerInvocation
+├── bootstrap/   BootstrapTask(interface)+Task-Beans · TaskRunner · TaskResult/BootstrapReport · InstallLayout
+│               · DependencyInstaller · SelfUpdateCommand · BinaryUpdater · BuildInfo
 ├── doctor/      DoctorService
 └── runtime/     YamlMapperProducer · SotPaths · AssetExtractor · ReflectionConfig
 
 src/main/resources/   application.properties · config/default_config.yml · templates/vault/secrets.yml (Qute)
-                      · ansible/** · docker/** · modules/**/module.yml · assets/manifest.txt (build-generiert)
-repo-root/            pom.xml · mvnw · install.sh · jreleaser.yml · .pre-commit-config.yaml
-                      · .github/workflows/{ci,native-build,release}.yml
+                      · apps/**/app.yml (gebündelte Default-Apps) · ansible/** · docker/** · assets/manifest.txt (build-generiert)
+repo-root/            build.gradle · settings.gradle · gradle.properties · gradlew · Justfile · install.sh
+                      · jreleaser (Gradle-Plugin) · .pre-commit-config.yaml · .github/workflows/{ci,native-build,release}.yml
 ```
 
-### Sieben Architektur-Prinzipien
+### Schichten-Diagramm
 
-1. **Ein Dispatch-Pfad.** `CommandLine.execute(args)` in `Main`. Kein `case`, kein Registry-vs-Filesystem-Dual, keine leeren Command-Pfade. Aliase sind `@Command(aliases=…)` — ein toter Alias ist **nicht kompilierbar**.
-2. **State per Konstruktor-Injektion, nie per argv.** Der positionale `CLI_METADATA_ARGS`-Contract (R3) existiert nicht mehr; Commands bekommen `SotConfig`, `SotPaths`, `VaultService` etc. als typisierte Beans.
-3. **Ein YAML-Parser, ein Schema.** `YamlMapperProducer` liefert **den einen** Jackson-`YAMLMapper`; Config sind unveränderliche Records. Die 4 Bash-Parser und das v1/v2-Schisma sind weg.
-4. **Ein Erweiterungs-Konzept.** `CapabilityProvider` mit zwei Strategien (lokales Verzeichnis / entferntes Git-Repo) hinter **einer** Registry + einem Lifecycle. `integration`-Typ und Legacy-Kommando entfallen.
-5. **Secrets sind ein Typ, kein String.** `Secret` (AutoCloseable `char[]`, `toString()="****"`, `close()` nullt) — nie auf argv, nie im Config-YAML, nie im Log. `no_log` wird zur Typ-Eigenschaft.
-6. **Ein Install-Root, ein Binary.** Alle Pfade aus **einem** `rootDir`. Kein Doppel-Clone, kein `/opt/AAT`-Fallback, kein CLI-Sed-Patch. Der ausgeführte CLI **ist** der installierte.
-7. **Build-Time-Wahrheit.** Command-Baum, Provider-Liste, Task-Liste, Completion, Hilfe, Version werden zur **Build-Zeit** aufgelöst (Closed-World). Erweitern = ein Bean hinzufügen, nicht ein `.sh` zur Laufzeit ablegen.
+```mermaid
+graph TD
+    IN["curl … install.sh | bash → natives sot-Binary"] --> CLI
+    subgraph CLI["cli/ + cli/app/ — Picocli + App-Selektor"]
+      ROOT["SotCommand @TopCommand"] --> APPC["AppCommand (Selektor/list/install/update/outdated)"]
+    end
+    APPC --> AS["app/ AppService (Lifecycle-Owner)"]
+    AS --> CAT["AppCatalog (git/http/bundled — Laufzeit-Daten)"]
+    AS --> STR["InstallStrategy ×5 (einkompiliert)"]
+    AS --> UPD["app.update/ UpdateMonitorService"]
+    UPD --> VR["VersionResolver ×5"]
+    STR --> PROC["process/ ProcessRunner · GitService · GitHubReleaseClient"]
+    VR --> PROC
+    ROOT --> OTHER["config/ · vault/ · bootstrap/ · doctor/"]
+    PROC --> EXT["ansible · git · docker · apt · terraform (externe Prozesse)"]
+    AS --> RT["runtime/ SotPaths · YamlMapper · AssetExtractor · ReflectionConfig"]
+    CAT -.Manifeste.-> CATREPO["Katalog-Repo (app.yml, index.yml) — extern, dynamisch"]
+```
+
+### Sieben Prinzipien
+1. **Zwei Achsen getrennt:** Kataloge (Daten, dynamisch) vs. Strategien (Beans, einkompiliert) → tief dynamisch trotz Closed-World.
+2. **Ein Dispatch-Pfad** (`CommandLine.execute`), ein Vokabular (`sot app`), tote Aliase nicht kompilierbar.
+3. **State per Konstruktor-Injektion**, nie positional argv (R3 aufgelöst).
+4. **Ein YAML-Parser, ein Schema** — Config & Manifeste durch denselben typisierten `YAMLMapper`.
+5. **Secrets sind ein Typ** (`Secret`), nie auf argv/Config/Log.
+6. **Ein Install-Root, ein Binary** — alle Pfade aus `SotPaths`; der ausgeführte CLI ist der installierte.
+7. **Build-Time-Wahrheit** — Command-Baum, Strategien, Resolver, Tasks zur Build-Zeit aufgelöst (`@All`).
 
 ---
 
-## 4. Was sich **nicht** ändert (Scope-Grenze)
+## 6. Capability-Mapping: Bash → Java
 
-- **Ansible / Terraform / Docker bleiben.** Sie werden als externe Prozesse orchestriert; Playbooks/Rollen/Templates sind eingebettete Assets. „Alles auf Java" heißt: **die gesamte Shell-Logik** wird Java — nicht die deklarativen Infrastruktur-Artefakte (die zu Java zu machen wäre absurd).
-- **Die Ziel-Fähigkeiten** (bootstrap, doctor, vault, runner, extensions, plugins, update/self-update, delete, help, version, interactive, completion) bleiben identisch aus Nutzersicht — nur robuster und sicherer.
-- **YAML als Config-Format** bleibt (verschachtelt), nur eben typisiert geladen.
+**Legende:** **[S]** = löst sich *strukturell* auf · **[C]** = *bewusst zu härten* · **[L]** = *manuell in den Ansible-Assets zu fixen*.
 
----
-
-## 5. Capability-Mapping: Bash → Java
-
-**Legende:** **[S]** = löst sich *strukturell* auf (das Java-Design macht den Befund per Konstruktion unmöglich) · **[C]** = braucht *bewusste Härtung* (Restrisiko bleibt, wird mitigiert — siehe §7/§9).
-
-| Bash-Datei / Subsystem | Ersetzt durch (Java) | Grundursache / Thema |
+| Bash | Java-Ersatz | Grundursache |
 |---|---|---|
-| `bin/sot` (Pfad-Bootstrap, `CLI_METADATA_ARGS`, `case`-Dispatch, `resolve_command_path`, interaktiv) | `cli.Main` + `SotCommand`-Baum + Konstruktor-Injektion | **R3** positional argv; **A** Doppel-Dispatch — [S] |
-| `lib/cli/registry.sh` (register/help/menu/completion-Gen) | `SotCommand`-Baum + `AliasCheatSheetRenderer` + `InteractiveCommand` | **A/I** Registry-vs-FS; Hilfe-Drift; leere Plugin-Pfade — [S] |
-| `lib/cli/aliases.sh` | picocli `@Command(aliases=…)` + `AliasExpander` | **F** toter `s`→setup-127-Exit; tote/Multi-Wort-Aliase — [S] |
-| `lib/cli/progress.sh`, `colors.sh` + 6 kopierte ANSI-Blöcke | `cli.ConsoleService` / `ProgressReporter` (ein Binary) | **R6** Farb-Duplikation; **E** — [S] |
-| `completions/*.{bash,zsh}` | picocli `AutoComplete.GenerateCompletion` | **R7/I** Completion-Triplikation + Drift — [S] |
-| `lib/core/yaml_parser.sh`, `parse_plugin_yaml`, `config_defaults`-Regex, `default_config{,_v2}.yml` | `YamlConfigCodec` + `YamlMapperProducer` + **ein** `default_config.yml` + `SotConfig`-Records | **R1** 4 Parser/Schema-Split; **D** flach-vs-verschachtelt; **G** `#`-Truncation/`xargs`-Korruption; **H** `PATH`/`IFS`-Key-Injection — [S] |
-| `config_defaults.sh` (`generate_dynamic_defaults`) | `PlaceholderResolver` + `GeneratedValue` + `ConfigValidator`-Gate | **F** `__GENERATE_SCRIPTS_DIR__` landet auf Disk — [S] |
-| `config_writer.sh`, `sed`, `save_plugin_state`, `overrides/` | `ConfigService.save` + `ConfigMerger` | **D** 3 Mutations-Pfade + unimplementierte Overrides — [S] |
-| `lib/plugins/manager.sh` + `lib/extensions/manager.sh` + `commands/extensions.sh` (3 Manager, 4 Begriffe) | `CapabilityRegistry` + `CapabilityService` + `CapabilityProvider`-Strategien | **R2/B** vier Begriffe, drei disjunkte Subsysteme — [S] |
-| `modules/*/module.yml`, `parse_plugin_yaml`, `PLUGIN_DEPENDENCIES` | `ExtensionManifest` + `ManifestParser`; topologische Dep-Auflösung | **B** Schema-vs-Parser; ignorierte Deps; Typ-Taxonomien — [S] |
-| `_update_config_value` / `save_plugin_state` (persistiert nie) | `CapabilityStateStore` | **B/F** Persistenz-Lüge — [S] |
-| `commands/vault.sh`, `roles/{vault,read_vault_parameter}`, `vault_template.j2` | `VaultService` + `AnsibleVaultRunner` + `Secret` + `TransientPasswordFile` + `VaultTemplateRenderer` | **R5/H** Secret auf argv, Klartext in Config, persistente `vault_pass.txt`, Debug-Dump, schwache Defaults, fehlende view/rekey — [S]; Symlink-Race, tmpfs-Garantie, Secure-Delete — [C] |
-| `commands/runner.sh` (ansible/terraform, tee, sync_repo), `trigger.sh` | `ProcessRunner` + `runner.*Invocation` + `TeeSink` + `ToolPreflight` | **R3/R6** positional argv + duplizierter Arg-Bau — [S] |
-| Git-Clone (`init.sh`/`tasks.sh`), `manager.sh` fetch+pull, `update.sh` `reset --hard`+`clean` | `GitService.gitSync(GitSyncSpec, PULL/RESET_HARD)` | **R6** 4 Git-Sync-Stellen; **G** ungeschützter Reset — [S]; RESET_HARD-Datenverlust — [C] |
-| `bootstrap/init.sh` curl\|bash Selbst-Clone + re-exec + re-clone | `install.sh` (dünn) + Prebuilt-Binary + `InstallLayout` | **R4** zwei Roots; **C** Selbst-Clone/CLI-Edit/`SETUP_DIR` — [S]; Root-Default-Wahl — [C] |
-| `bootstrap/{tasks,runner,args_parser}.sh` | `BootstrapTask`-Beans + `TaskRunner` + `BootstrapReport` | **F** „immer erfolgreich"-Lüge; unparste `$1/$2` — [S] |
-| `bootstrap/dependencies.sh` | `DependencyInstaller`-Strategien | **F** still verworfene `-tools`-Tokens — [S] |
-| `commands/maintenance/update.sh` | `SelfUpdateCommand` + `BinaryUpdater` + `ChecksumVerifier` + `GitHubReleaseClient` | **G/H** ungeschützter Reset; unverifiziertes Update — [S]; Cross-Device-Move, TLS/CA — [C] |
-| `commands/maintenance/delete.sh` (safe-delete, vault-backup) | `SafeFsRemover` + `PathGuardTest`-Denylist | **R5/H** `rm -rf` auf Config-Pfade + sed-Injection; Secret in `/tmp/BACKUP_INFO.txt` — [S] |
-| `lib/init.sh` Source-Loader/Doppel-Sourcing, `SOT_ROOT`-Probing | `runtime.SotPaths` + Arc-Bean-Graph | **R4/E** Load-Modell, Doppel-Source, `SCRIPT_ROOT`-Drift — [S] |
-| `modules/ansible/**`, Templates, Docker (loser Baum) | `src/main/resources/**` + `AssetExtractor` (+ `assets/manifest.txt`) | Asset-Embedding für native — [S]; Manifest-Vollständigkeit — [C] |
-| **`modules/ansible/roles/*` INHALT (UFW, Rollenname, hosts-Regex, Vault-Lifecycle, OS-Abstraktion)** | **portierte, gefixte Ansible-Assets** (bleiben YAML) | **Thema L (10 Befunde)** — **NICHT [S]/[C], sondern manuell zu fixen** ⚠️ |
-| `tests/*.sh` + Mock-`ansible-vault` | `@QuarkusTest` + `RecordingProcessRunner` + `FakeToolPathResource` + `ConfigRoundtripTest` + `VaultBehaviorTest` | **K** grep-String-Tests, `set -e`-Counter, Null-Coverage, bash≥4/macOS-3.2 — [S] |
-| `.github/workflows/{test,lint,security,deploy}.yml`, `.pre-commit-config` | `ci.yml` + `native-build.yml` + `release.yml` + `jreleaser.yml` | **R7** False-Green `security.yml` `\|\| true`, `ci/`-Drift; **I** — [S]; native musl/exec — [C] |
+| `bin/sot`-Dispatch, `CLI_METADATA_ARGS` | `cli.Main` + `SotCommand`-Baum + Konstruktor-Injektion | R3, A — [S] |
+| `lib/cli/{registry,aliases,progress}.sh`, `colors.sh` + 6 ANSI-Kopien, `completions/*` | `cli/` (Command-Baum, `ConsoleService`, `AutoComplete.GenerateCompletion`) | A/E/I/R6/R7 — [S] |
+| `lib/core/yaml_parser.sh` + 3 weitere Parser, `default_config{,_v2}.yml` | `YamlConfigCodec` + `YamlMapperProducer` + `SotConfig`-Records | R1/D/G/H — [S] |
+| `lib/plugins/manager.sh` + `lib/extensions/manager.sh` + `commands/extensions.sh` (3 Manager, 4 Begriffe) | **`app/` App-Manager** (`AppService`+`AppCatalog`+`InstallStrategy`) — Extension = App mit `runner:` | R2/B — [S] |
+| `modules/*/module.yml`, `parse_plugin_yaml`, `PLUGIN_DEPENDENCIES` | `AppManifest` + `ManifestParser` + topologische `requires.apps` | B — [S] |
+| `_update_config_value`/`save_plugin_state` (persistiert nie) | `InstalledAppStore` (typisiert, atomar) | B/F — [S] |
+| *(neu — Anforderung B)* Update-Überwachung | **`app.update/` `UpdateMonitorService` + `VersionResolver`-SPI** + systemd-Timer | neue Fähigkeit — [C] |
+| `commands/runner.sh`, `trigger.sh` | `process.ProcessRunner` + `runner.*Invocation` | R3/R6 — [S] |
+| Git-Sync (4×), `update.sh` `reset --hard` | `GitService.gitSync(PULL/RESET_HARD, --force-gated)` | R6/G — [S]; Datenverlust — [C] |
+| `commands/vault.sh`, Vault-Rollen, `vault_template.j2` | `vault.VaultService` + `Secret` + `TransientPasswordFile` + Qute | R5/H — [S]; tmpfs/Race — [C] |
+| `bootstrap/init.sh` curl\|bash Selbst-Clone | **`install.sh` (dünn) + Prebuilt-Binary** + `InstallLayout` | R4/C, A — [S]; Root-Wahl — [C] |
+| `bootstrap/{tasks,runner,args_parser,dependencies}.sh` | `BootstrapTask`-Beans + `TaskRunner` + `DependencyInstaller` | F — [S] |
+| `commands/maintenance/{update,delete}.sh` | `SelfUpdateCommand`/`BinaryUpdater` + `SafeFsRemover` | G/H — [S]; Cross-Device/TLS — [C] |
+| **`modules/ansible/roles/*` INHALT** (UFW `allow`, Rollenname, hosts-Regex, Vault-Lifecycle, OS) | **portierte, gefixte Ansible-Assets** (bleiben YAML) | **Thema L (10) — manuell [L]** ⚠️ |
+| `tests/*.sh` + Mock-vault | `@QuarkusTest`/`@QuarkusMainTest`/native-IT + `RecordingProcessRunner` | K — [S] |
+| `.github/workflows/*`, `.pre-commit` | `ci/native-build/release`.yml (Gradle) + JReleaser | R7/I — [S]; native musl/exec — [C] |
 
-**Bilanz der 88 Befunde:** ~geschätzt **60+ lösen sich strukturell [S]** (Themen A, B, D, E, F, I, J, K + R1/R2/R3/R4-Layout/R6/R7). **~8–10 brauchen bewusste Härtung [C]** (native Reflection/Ressourcen, Linking, Secret-Härtung, Legacy-Migration, Self-Replace, Manifest-Vollständigkeit). **10 (Thema L) lösen sich gar nicht** — sie müssen in den portierten Ansible-Assets **aktiv gefixt** werden (Phase 6).
+**Bilanz:** Der Großteil der 88 Befunde löst sich **strukturell [S]** auf; ~8–10 brauchen **Härtung [C]** (native Reflection/Ressourcen, Linking, Secrets, Legacy-Migration, Self-Replace, **Supply-Chain der Kataloge**, Update-Fan-out); **10 (Thema L)** sind manuell in den portierten Ansible-Assets zu fixen (Phase 7).
 
 ---
 
-## 6. Native-Image-Constraints (die echten Fallstricke)
+## 7. Native-Image-Constraints
 
 | Bereich | Was zu tun ist |
 |---|---|
-| **Reflection** | `@RegisterForReflection` auf **alle** Jackson-Records (`SotConfig` + Sektionen, `ExtensionManifest`, `VaultSecrets`, GitHub-Release-DTOs) **zentral in `ReflectionConfig`** — sonst Runtime-Fehler „missing constructor". Picocli-`IVersionProvider`/`IHelpSectionRenderer`/`IExitCodeExceptionMapper`/`GenerateCompletion` ebenfalls registrieren. |
-| **Ressourcen** | `quarkus.native.resources.includes=ansible/**,docker/**,templates/**,config/**,modules/**,assets/manifest.txt` — sonst fehlen die Assets im Binary. Ein natives Binary kann Classpath-Ressourcen **nicht `Files.walk`en** und **nicht direkt exec**en → `AssetExtractor` iteriert das build-generierte `assets/manifest.txt` und kopiert jede Ressource (idempotent, content-hash, 0700) in ein beschreibbares Verzeichnis, **bevor** ProcessBuilder ansible/git/docker aufruft. |
-| **Closed-World** | Kein `Class.forName`, kein Runtime-Scanning. CDI-Beans, Command-Baum, `@All List<CapabilityProvider>`, `@All List<BootstrapTask>` werden zur Build-Zeit aufgelöst. |
-| **Build- vs Runtime-Init** | `$SOT_HOME`/Env zur **Laufzeit** lesen (`SotPaths @ApplicationScoped`); `YAMLMapper` build-time via `@Produces`; Version/Commit als generierte `BuildInfo`-Ressource (kein Runtime-`git`); `SecureRandom` `--initialize-at-run-time`. |
-| **Charsets** | `quarkus.native.add-all-charsets=true` + UTF-8 `file.encoding` (deutsche Ausgabe, Non-ASCII-Vault) — im Native-Smoke-Test prüfen. |
-| **Prozess-Exec + Linking ⚠️** | `ProcessBuilder` nutzt `posix_spawn`. **ABER: voll-statische (musl) native Images können nicht fork/exec** — und das ganze Tool ruft externe Prozesse auf. Linux daher **mostly-static (glibc) oder dynamisch**, **nicht** `--static --libc=musl`. CI muss echten Subprozess-Aufruf aus dem gebauten Binary beweisen. |
-| **TLS (Self-Update)** | JDK-`HttpClient` über TLS braucht `quarkus.ssl.native=true` + eingebetteten CA-Truststore (mit Override). SHA-256 via `MessageDigest` ist Default. |
+| **Closed-World-Dynamik (Kernmuster)** | Strategie-/Resolver-**Menge** einkompiliert via `@All List<InstallStrategy>`/`@All List<VersionResolver>` → `Map<enum,bean>` zur Build-Zeit; **welche Apps** existieren = reine Laufzeit-Daten (git/http-Manifeste). Kein `Class.forName`, kein Runtime-Classloading. |
+| **Reflection** | `@RegisterForReflection` zentral in `ReflectionConfig` für **alle** Jackson-Records: `AppManifest`, `SourceSpec`, `VersionSpec`, `Requires`, `InstallSpec`, `RunnerSpec`, `CatalogIndex`, `InstalledApp`, **jede Strategie-Option-Slice**, GitHub-/Docker-Registry-DTOs, Report-Records, `AppNameCandidates`, Picocli-Provider. Sonst binden sie **null**. |
+| **Polymorphie** | `SourceSpec` generisch (`AppSourceType` + roher `JsonNode`), per-Strategie-Binding in `resolve()` — **kein** Jackson `@JsonSubTypes` (bläht die Reflection-Fläche). |
+| **Ressourcen** | Gebündelte Apps unter `src/main/resources/apps/**/app.yml`; `resources.includes` + `AssetExtractor` iteriert das **build-generierte** `assets/manifest.txt` (native kann Classpath nicht `Files.walk`en). |
+| **TLS** | `quarkus.ssl.native=true` + eingebetteter CA-Truststore (api.github.com, ghcr.io, registry-1.docker.io, Debian-Mirror) — geteilt mit Self-Update. |
+| **Prozess-Exec + Linking ⚠️** | **musl-static kann nicht fork/exec** — und jede Install/Update/Version-Prüfung ruft externe Tools. Daher **mostly-static glibc** (`-H:+StaticExecutableWithDynamicLibC`). CI muss echten Subprozess-Aufruf aus dem Binary beweisen. |
+| **Kein Daemon** | Scheduling via externe systemd/cron-Unit (von bootstrap materialisiert); Binary läuft je Tick einmal. |
+| **Kein JLine/ncurses** | Selektor = ANSI-Writes + Zeilen-Reads; `System.console()==null` → verweigern. `Clock` injizieren (deterministisch). |
 
 ---
 
-## 7. Offene Entscheidungen (vor bzw. in Phase 0 zu fixieren)
+## 8. Offene Entscheidungen
 
-Der Multi-Agenten-Entwurf hat echte Widersprüche zwischen den Schichten aufgedeckt. Empfehlung je Zeile; die mit ⚠️ sind **load-bearing**.
+Der Multi-Agenten-Entwurf hat Widersprüche zwischen Schichten aufgedeckt; hier **aufgelöst** (⚠️ = load-bearing, bitte bestätigen).
 
-| # | Entscheidung | Empfehlung | Anmerkung |
-|---|---|---|---|
-| **D1** ⚠️ | **Native-Linking:** static-musl vs mostly-static-glibc | **mostly-static glibc / dynamisch** | **Keine echte Wahl, sondern Korrektheits-Constraint:** static-musl kann nicht fork/exec → Tool wäre kaputt. Zwei Schicht-Entwürfe hatten fälschlich musl-static gewählt. |
-| **D2** | **Root-Package / groupId** | `de.jklein.sot` (= groupId) | Agenten schlugen 5 verschiedene vor; auf einen normiert. |
-| **D3** | **Install-Root + Symlink** | Root `/opt/sot`, Symlink `/usr/local/bin/sot`; `SotPaths` & `InstallLayout` zu **einem** Pfadmodell mergen | Löst R4; bestätige die Pfadwahl. |
-| **D4** | **Vokabular „Capability" vs „Extension"** | **Extension** durchgängig (User-Term = `sot extensions`/`ex`); interne Klassen konsistent benennen | Aktuell mischt der Entwurf `Capability*`-Klassen mit `extension/`-Package. |
-| **D5** | **`ProcessRunner`** Interface vs konkret | **Interface + `ProcessRunnerImpl`** | Tests brauchen das Interface (`@InjectMock`/`@Alternative`). |
-| **D6** | **Geteilte Beans deduplizieren** | je **ein** `YAMLMapper`, **ein** `Secret`-Typ, **ein** `SecretMaterializer`, **ein** `AssetExtractor`, **ein** `ProcessRunner` | Mehrere Schichten beanspruchten dieselbe „single source" — genau einmal implementieren. |
-| **D7** | **macOS-Scope** | **v1: Linux nativ (primär); macOS nur JVM/Dev.** Natives macOS-Binary + Vault-tmpfs-Strategie später | macOS hat kein `/dev/shm`; native Static-Linking ist ohnehin Linux. **Bitte bestätigen.** |
-| **D8** | **Self-Update** | Beide: `install.sh` (Erstinstallation) + `sot self-update` (Upgrade), **beide** verifizieren Checksum **+ cosign** | Angleichen (eine Schicht hatte nur `shasum`). |
-| **D9** | **Legacy-Config-Migration** | Einmal-Migrations-Reader (`FAIL_ON_UNKNOWN=false` + Key-Mapping) → schreibt kanonisches Schema, dann strikt | Nur nötig, falls **produktive SOT-Installationen im Feld** existieren — **bitte bestätigen** (sonst Greenfield). |
-| **D10** | **`module.yml` `apiVersion`** | Von Anfang an mitführen (warn-not-fail-Fenster) | Deckt zugleich D9-Manifest-Evolution ab. |
+| # | Entscheidung | Festlegung |
+|---|---|---|
+| **D1** ⚠️ | Native-Linking | **mostly-static glibc** — Korrektheits-Constraint (fork/exec); CI beweist Subprozess-Exec vor Release |
+| **D2** | Root-Package | `de.jklein.sot` |
+| **D3** ⚠️ | Install-Root + Symlink | Root **`/opt/sot`**, Symlink `/usr/local/bin/sot`; `SotPaths`/`InstallLayout` zu **einem** Modell mergen — **bitte bestätigen** |
+| **D4** | Extension/Plugin-Schicht | **Kollabiert in den App-Manager** — Extension = App mit `runner:`; alte Namen nur als Aliase |
+| **D5** | „latest version" — zwei Designs | **`InstallStrategy` (install/update/remove) delegiert an `VersionResolver` (latest)** — orthogonale Achsen (`source.type` ≠ `version.strategy`), kein Doppel-Design |
+| **D6** | Strategie-Vokabular | `AppSourceType{GIT_REPO,DOCKER_COMPOSE,GITHUB_RELEASE_BINARY,APT_DEB,SCRIPT}` (install) ⟂ `UpdateStrategy{GITHUB_RELEASE,GIT_TAG,DOCKER_IMAGE,APT,STATIC,SCRIPT}` (version) |
+| **D7** | `AppService`-Kontrakt | **Ein** Interface (Domänen-Form + Read-Views `catalog()/installed()/outdated()`) |
+| **D8** | Katalog-Refresh-Name | Kanonisch `sot app catalog refresh` (`sot app refresh`/`sync` als Alias) |
+| **D9** | Semver | Hand-gerollt native-sicher (`Version`/`VersionConstraint`); `org.semver4j` als Fallback |
+| **D10** | Scheduling | systemd-Timer (Cron-Fallback) → `sot app check --quiet --notify`; kein In-Process-Daemon |
+| **D11** ⚠️ | **Katalog-Trust (Supply-Chain)** | `CatalogSource.trust` (gepinnter git-ref / cosign+sha256 für http-index); **`script`-Strategie erfordert interaktive Bestätigung**, außer signiert+trusted; dein eigener Katalog ist die einzige Default-Trusted-Quelle — **bitte bestätigen** |
+| **D12** | Rate-Limits/Auth | ETag-Conditional-GETs + TTL-Cache + Serve-Stale; optionaler PAT; Docker-Bearer-Flow |
+| **D13** | Selektor-UI | Zeilenorientiert (kein JLine) |
+| **D14** | Build-DSL | Groovy (Quarkus-Default) |
+| **D15** | JReleaser | Gradle-Plugin (`jreleaserFullRelease`) |
+| **D16** | `install.sh` apt-installs? | **Nein** — nur das `sot`-Binary; Tools via `doctor`/`bootstrap` |
+| **D17** | Version-Pin im Ein-Zeiler | Default `releases/latest`; `SOT_VERSION`/Positional pinnt |
+| **D18** | cosign | Keyless (Fulcio/Rekor, GitHub-OIDC); sha256 Pflicht, cosign best-effort |
+| **D19** ⚠️ | macOS-Scope | v1 **Linux nativ** (amd64/arm64); macOS nur JVM/Dev — **bitte bestätigen** |
+| **D20** | Legacy-Migration | Einmal-Reader (`FAIL_ON_UNKNOWN=false` + Key-Mapping); `module.yml`→`app.yml` (Docker-Templates in je eigene compose-Apps) — nötig nur bei **Feld-Installationen** — **bitte bestätigen** |
 
 ---
 
-## 8. Migrations-Phasen (Greenfield-Neubau, „Strangler" bis Parität)
+## 9. Migrations-Phasen (Greenfield, „Strangler" bis Parität)
 
-Neubau in einem neuen Maven-Modul, **Fähigkeit für Fähigkeit**, jede Phase eine reviewbare PR mit **Abnahme-Gate**. Der alte Bash-Baum bleibt bis Phase 8 (Cutover) lauffähig als Referenz. Aufwand: **S** ≤ 2 Tage, **M** ≈ 3–5 Tage, **L** ≈ 1–2 Wochen (eine Person).
+Neubau in einem Gradle-Modul, Fähigkeit für Fähigkeit, jede Phase eine PR mit **Abnahme-Gate**. Aufwand: **S** ≤ 2 T, **M** ≈ 3–5 T, **L** ≈ 1–2 Wo.
 
-### Phase 0 — Projekt-Skelett & Foundation *(L · blockiert alles · fixiert D1–D6)*
-Maven/Quarkus/Java-21-Setup; Package-Baum; `quarkus-picocli`-Hello-World `sot version`; `YamlMapperProducer`, `SotPaths`, `AssetExtractor`, `ReflectionConfig`, `application.properties` (resources.includes, add-all-charsets, Mandrel-Image); dünnes `install.sh`-Stub; `ci.yml` mit **JVM-Verify + einem linux-amd64-Native-Smoke** (`sot version` als Native-Binary). **Linking-Entscheidung D1 hier verifizieren** (Native-Binary ruft `git --version` erfolgreich auf).
-**Gate:** `sot version` läuft als natives Binary in CI; Native-Binary kann einen externen Prozess starten (beweist mostly-static-glibc).
-
-### Phase 1 — Config-Kern *(L · hängt an 0 · löst R1/D)*
-`SotConfig`-Records (verschachtelt), `YamlConfigCodec`, `ConfigMerger`, `PlaceholderResolver` + `GeneratedValue`, `ConfigValidator`, `SecretStore` (0600-Referenz statt Secret-Feld). `default_config.yml` als einzige kanonische Vorlage.
-**Gate:** `ConfigRoundtripTest` (`load(save(cfg))==cfg`, Golden-File, jqwik-Properties inkl. `#`/Quote/CRLF); Native-IT lädt `default_config.yml` und bindet alle Sektionen.
-
-### Phase 2 — Prozess-/Exec-Engine *(M · hängt an 0 · löst R6/R3-argv)*
-`ProcessRunner`(Interface)+Impl mit Virtual-Thread-Draining, `ProcessSpec/Result`, `TeeSink`, `GitService.gitSync` (PULL/RESET_HARD, `--force`-gated), `SecretMaterializer` (0600-Datei/stdin/env, nie argv), `WorkspaceManager`, `ToolPreflight`, typisierte `runner.*Invocation`-Records.
-**Gate:** Tests mit `RecordingProcessRunner` (kein echtes ansible/git); Native-Smoke ruft echtes `git`/`echo` auf (härtet D1 endgültig ab).
-
-### Phase 3 — CLI-Gerüst & Dispatch *(L · hängt an 1+2 · löst A/F-Dispatch, R3)*
-`SotCommand`-Baum, `Main`, globale Optionen (`scope=INHERIT`), Hilfe/Version, `GenerateCompletion`, `@Command(aliases=…)` + `AliasExpander`, `InteractiveCommand`, `SotExitCode`, `ConsoleService`. Commands als dünne Schalen, die (teils gestubte) Services aufrufen.
-**Gate:** `@QuarkusMainTest` e2e über `sot help`/`--help`/`generate-completion`/Exit-Codes; Completion deckt exakt den Command-Baum.
-
-### Phase 4 — Vault & Security *(L · hängt an 1+2 · löst R5/H)*
-`Secret`(AutoCloseable), `VaultPasswordSource`(sealed)+`SecretResolver`, `TransientPasswordFile`+`PosixGuards` (tmpfs-verifiziert, fail-loud), `AnsibleVaultRunner` (Passwort via Datei/stdin), `SecretGenerator`, Qute-`secrets.yml`, `VaultService` (init/view/edit/rekey/read — view+rekey **neu funktional**), `VaultCommand`.
-**Gate:** `VaultBehaviorTest` (kein Secret in argv/`ps`, 0600-tmpfs-Datei, nach Nutzung weg); Container-IT: echter `ansible-vault` encrypt→decrypt-Roundtrip.
-
-### Phase 5 — Extensions/Capability *(L · hängt an 1+2+3 · löst R2/B)*
-`CapabilityProvider` + `LocalDirectoryProvider`/`RemoteGitProvider`, `CapabilityRegistry` (`@All`), `CapabilityService` (list/info/install/remove/enable/disable/sync/run), `ExtensionManifest`+`ManifestParser` (apiVersion), `CapabilityStateStore` (echte Persistenz), `SafeFsRemover`, `ExtensionsCommand`/`PluginsCommand`.
-**Gate:** `ExtensionManagerTest` — install/enable/sync/**persist**-Roundtrip über beide Provider; kaputtes `module.yml` schlägt bei Discovery fehl.
-
-### Phase 6 — Bootstrap, Runner & Ansible-Assets *(L · hängt an alle Services · löst C/F + Thema L)*
-`BootstrapTask`-Pipeline + `TaskRunner`/`BootstrapReport` (ehrlicher Exit), `DependencyInstaller`-Strategien, `InstallLayout`, `RunnerCommand` verdrahtet die Invocation-Records, `AssetExtractor` der eingebetteten `ansible/`. **Zusätzlich: die portierten Ansible-Assets fixen** — UFW `deny`, Rollenname `read_vault_parameter`, `/etc/hosts`-Regex, Vault-Passwort-Lifecycle, OS-Abstraktion (`package` + `when: ansible_os_family`), `ansible_facts`-Missbrauch, Docker aus Trigger lösen (**Thema L**).
-**Gate:** `sot bootstrap` bringt einen Wegwerf-Container in definierten Zustand; `ansible-lint` grün; Vault-encrypt→decrypt-Roundtrip in der Ansible-Rolle grün.
-
-### Phase 7 — Self-Update, Packaging & Release *(L · hängt an 0 + App · löst R7)*
-`GitHubReleaseClient`+`ChecksumVerifier`+`BinaryUpdater` (Sibling-Temp → verify → `ATOMIC_MOVE` → re-exec), JReleaser-Multi-Arch (linux amd64/arm64), `install.sh` vollständig (Checksum + cosign), `release.yml` (Tag `v*`), `native-build.yml`-Matrix, `.pre-commit-config` (Spotless/shellcheck-für-install.sh/yamllint/ansible-lint/gitleaks).
-**Gate:** Getaggter Release erzeugt verifizierte Per-Plattform-Binaries; `install.sh` installiert sie; `sot self-update`-Roundtrip funktioniert.
-
-### Phase 8 — Parität, Cutover & Legacy-Migration *(M · final)*
-Volle Testabdeckung (extensions/bootstrap/config/doctor/maintenance); Legacy-`config.yaml`-Migrations-Reader (D9); **die 88-Befund-Regressions-Checkliste abarbeiten** (jedes [S] nachweislich weg, jedes [C] nachweislich mitigiert, Thema-L-Fixes verifiziert); alten Bash-Baum entfernen; README/Docs neu schreiben.
-**Gate:** Paritäts-Checkliste 100 %; Bash entfernt; `refactoring-findings.md` vollständig abgehakt.
+- **Phase 0 — Skelett & Foundation** *(L · fixiert D1–D4)* — Gradle/Quarkus/Java-21, `Justfile`, `quarkus-picocli`-`sot version`, `YamlMapperProducer`/`SotPaths`/`AssetExtractor`/`ReflectionConfig`, `ci.yml` mit **JVM-Verify + linux-amd64-Native-Smoke, der einen echten Subprozess startet** (verifiziert D1). **Gate:** `sot version` nativ + Native-Binary ruft `git --version`.
+- **Phase 1 — Config-Kern** *(L · löst R1/D)* — `SotConfig`-Records, `YamlConfigCodec`, Merge/Placeholder/Validator, `SecretStore`, `CatalogSource`-Liste in der Config. **Gate:** Config-Roundtrip + native-IT bindet `default_config.yml`.
+- **Phase 2 — Prozess-/Exec-Engine** *(M · löst R6)* — `ProcessRunner`+Impl, `GitService`, `GitHubReleaseClient`, `ChecksumVerifier`, `SecretMaterializer`, `WorkspaceManager`, `ToolPreflight`. **Gate:** Native-Smoke ruft echtes `git`.
+- **Phase 3 — CLI-Gerüst** *(M · löst A/F-Dispatch)* — `SotCommand`-Baum, `Main`, Hilfe/Version/Completion, Aliase, Exit-Codes, `ConsoleService`. **Gate:** `@QuarkusMainTest` e2e.
+- **Phase 4 — ★ App-Manager Kern** *(L · Anforderung B, löst R2/B)* — `AppManifest`+`ManifestParser`, `AppCatalog` (git/http/bundled), 5 `InstallStrategy`-Beans, `AppService`, `InstalledAppStore`, `SafeFsRemover`, `requires`-Topo-Sort. **Gate:** install/update/remove/**persist** je Strategie über einen Test-Katalog; kaputtes Manifest failt bei Discovery.
+- **Phase 5 — ★ Update-Überwachung** *(L · Anforderung B)* — `VersionResolver`-SPI (5), `UpdateMonitorService` (Virtual-Thread-Fan-out), `VersionCache` (ETag/TTL/Serve-Stale), `SemVer`/`VersionConstraint`, Pins, `UpdateScheduler`/`UpdateNotifier`. **Gate:** `outdated` über Mock-Resolver korrekt (up-to-date/outdated/pinned/unknown); Cache-Roundtrip.
+- **Phase 6 — ★ App-Selektor & Command-Surface** *(M · Anforderung B)* — `AppCommand`-Baum, `AppSelector` (zeilenorientiert), Renderer, alle Subcommands, `--json`/`--yes`, `AppNameCandidates`-Completion, `ex`/deprecated Forwarder. **Gate:** `@QuarkusMainTest` über list/install/outdated/selector; non-TTY→list.
+- **Phase 7 — Vault, Bootstrap, Runner & Ansible-Assets** *(L · löst R5/C/F + Thema L)* — `VaultService`+`Secret`+tmpfs, `BootstrapTask`-Pipeline, `DependencyInstaller`, `RunnerCommand`, systemd-Timer-Materialisierung; **Ansible-Assets fixen** (UFW `deny`, Rollenname, hosts-Regex, Vault-Lifecycle, OS-Abstraktion). **Gate:** `sot bootstrap` gegen Wegwerf-Container; `ansible-lint`; Vault-Roundtrip.
+- **Phase 8 — Install-Einzeiler, Packaging & Release** *(L · Anforderung A, löst R7)* — `install.sh` (uname/download/verify/PATH), `SelfUpdateCommand`+`BinaryUpdater`, JReleaser-Gradle-Multi-Arch, `native-build.yml`/`release.yml`, `.pre-commit`. **Gate:** Getaggter Release → verifizierte Binaries; **der Ein-Zeiler installiert `sot` in einem frischen Debian-Container**; `sot self-update`-Roundtrip.
+- **Phase 9 — Parität, Cutover & Legacy-Migration** *(M · final)* — volle Coverage, Legacy-`config.yaml`/`module.yml`→`app.yml`-Migrations-Reader, **88-Befund-Regressions-Checkliste** (jedes [S] weg, [C] mitigiert, [L] gefixt), Bash entfernen, README neu. **Gate:** Checkliste 100 %; `mvn`/`pom.xml`/`--libc=musl`-grep leer.
 
 ### Sequenz
-
 ```
-Phase 0 (Skelett/Foundation, fixiert D1–D6)
-   └─► Phase 1 (Config) ─┐
-   └─► Phase 2 (Exec) ───┤
-                         ├─► Phase 3 (CLI) ─► Phase 5 (Extensions)
-                         ├─► Phase 4 (Vault)          │
-                         └─► Phase 6 (Bootstrap+Runner+Ansible-Assets)
-Phase 7 (Release/Self-Update)  ── ab Phase 0 vorbereitbar, voll ab lauffähiger App
-Phase 8 (Parität/Cutover/Migration)  ── ganz zuletzt
+0 (Skelett, D1) → 1 (Config) & 2 (Exec)
+                     └→ 3 (CLI) → 4 (App-Kern) → 5 (Update-Monitor) → 6 (Selektor)
+                     └→ 7 (Vault/Bootstrap/Ansible)   [parallel ab 2]
+8 (Install/Release)  [ab 0 vorbereitbar, voll ab lauffähiger App]
+9 (Parität/Cutover)  [zuletzt]
 ```
-**Kritischer Pfad:** 0 → 1/2 → 3 → 5/6 → 8. Phase 4 parallel ab 2; Phase 7 parallel ab 0.
+**Kritischer Pfad:** 0 → 1/2 → 3 → 4 → 5 → 6 → 8 → 9. Der App-Manager (4–6) ist der Wertkern und der größte Brocken.
 
 ---
 
-## 9. Verifikationsstrategie
+## 10. Verifikationsstrategie
 
-- **Drei Test-Tiers:** (1) `@QuarkusTest` JVM-Komponententests mit gemocktem `ProcessRunner` (nie echtes ansible/git); (2) `@QuarkusMainTest` CLI-e2e über `QuarkusMainLauncher`; (3) `@QuarkusMainIntegrationTest` **native** Black-Box-Smoke mit `FakeToolPathResource` (echte Fake-Tools auf PATH).
-- **Native-Gate ist Pflicht:** Ein natives IT lädt Config, parst jedes echte `module.yml`, fährt einen Runner-Dry-Run — verwandelt Reflection-/Ressourcen-Fehler von Runtime-Überraschungen in gefangene CI-Fehler.
-- **Paritäts-Checkliste** gegen `refactoring-findings.md`: jeder der 88 Befunde bekommt einen Status (dissolved-[S] / hardened-[C] / ansible-fixed-L) mit Test- oder Code-Nachweis. Das ist das Abnahmekriterium für Phase 8.
-- **Verhaltens- statt Text-Tests** für Security (kein Secret in argv via `ps`; 0600-tmpfs).
-- **CI failt hart** (kein `|| true`); SonarCloud-Quality-Gate als Required-Check.
+- **Drei Test-Tiers:** `@QuarkusTest` (JVM, gemockter `ProcessRunner`/`VersionResolver`) · `@QuarkusMainTest` (CLI-e2e) · `@QuarkusMainIntegrationTest` (**native** Black-Box, `FakeToolPathResource`).
+- **Native-Gate Pflicht:** ein natives IT lädt Config, parst je ein Manifest **jedes** `source.type`, startet einen echten Subprozess (`git --version`) — verwandelt Reflection-/Linking-Fehler in gefangene CI-Fehler.
+- **Release-Smoke:** der publizierte Ein-Zeiler wird in einem **frischen Debian-Container** gegen den echten Release ausgeführt (Anforderung A).
+- **Paritäts-Checkliste** gegen `refactoring-findings.md`: jeder der 88 Befunde bekommt Status [S]/[C]/[L] mit Nachweis — Abnahme für Phase 9.
+- **Supply-Chain-Test:** ein unsigniertes Katalog-Manifest mit `script`-Strategie muss ohne Bestätigung **abgelehnt** werden.
+- **CI failt hart** (kein `|| true`).
 
 ---
 
-## 10. Risiken & Gegenmaßnahmen (Top 8)
+## 11. Risiken & Gegenmaßnahmen (Top 8)
 
 | # | Risiko | Gegenmaßnahme |
 |---|---|---|
-| 1 ⚠️ | **static-musl kann nicht fork/exec** (architektur-brechend) | **mostly-static glibc/dynamisch** bauen; libc im Asset-Namen; CI beweist Subprozess-Exec aus dem Binary vor jedem Release (D1) |
-| 2 | Native Reflection/Ressourcen-Miss zeigt sich erst zur Laufzeit | Zentrale `ReflectionConfig`; Pflicht-Native-IT (Config-Load + alle `module.yml` + Runner-Dry-Run); Build-Assert, dass jeder `resources.includes`-Glob + `manifest.txt`-Eintrag auflöst |
-| 3 | Secret-Restexposition (Heap-Copy, unsicheres Secure-Delete) | tmpfs(RAM)+0600+sofort-unlink+SecureRandom-Name+`O_EXCL`/`NOFOLLOW` (killt Symlink-Race 165); Overwrite = Best-Effort; try-with-resources; Core-Dumps aus; Restrisiko dokumentiert |
-| 4 | tmpfs fehlt/ist Disk (Container, macOS) → Passwort auf Platte | `PosixGuards` verifiziert echtes tmpfs und **failt laut** statt still zu persistieren; gatet zugleich macOS (D7) |
-| 5 | Legacy-`config.yaml` bricht striktes Binding | Einmal-Migrations-Reader (`FAIL_ON_UNKNOWN=false` + Key-Mapping) → kanonisch umschreiben, dann strikt (D9) |
-| 6 | Destruktiver `RESET_HARD`-Datenverlust (aus `update.sh`) | `SyncMode.RESET_HARD` nur mit `--force`; Default `PULL`; eine auditierte `GitService`-Methode |
-| 7 | Self-Replace scheitert Cross-Device/EACCES; TLS/CA bricht Download | Temp ins Zielverzeichnis, Checksum+cosign vor `ATOMIC_MOVE`, klare Fallback-Meldung bei EXDEV/EACCES; CA eingebettet + Override |
-| 8 | Lange/flaky Multi-Arch-Native-Builds, Mandrel-Drift | PRs: JVM-Verify + 1× linux-amd64-Smoke; volle Matrix nur auf Tag (`fail-fast:false`); Mandrel-Version + Builder-Image-Tag pinnen; Renovate-Bumps müssen das Native-Gate bestehen |
-
----
-
-## 11. Abhängigkeiten (Kurzliste)
-
-**Runtime:** `quarkus-picocli`, `quarkus-arc`, `quarkus-jackson`, `jackson-dataformat-yaml` (SnakeYAML), `quarkus-hibernate-validator`, `quarkus-qute`.
-**Test:** `quarkus-junit5`, `quarkus-junit5-mockito`, `quarkus-jacoco`, `assertj-core`, `jqwik`.
-**Build/Release:** `quarkus-maven-plugin`, `jreleaser-maven-plugin`, `spotless-maven-plugin`, `jacoco-maven-plugin`, `sonar-maven-plugin`; Actions: `graalvm/setup-graalvm@v1` (Mandrel 21, gepinnt), `anchore/sbom-action` (Syft), `sigstore/cosign`.
+| 1 ⚠️ | **musl-static kann nicht fork/exec** | mostly-static glibc; CI beweist Subprozess-Exec vor Release (D1) |
+| 2 ⚠️ | **Supply-Chain / RCE** — Katalog-Manifest mit `script`/deb-Strategie führt Fremdcode aus; `curl\|bash` ist MITM-Fläche | Kataloge signieren/pinnen (git-ref bzw. cosign+sha256); `script` nur mit Bestätigung außer trusted; `install.sh` sha256 **Pflicht** + cosign keyless, nur https (D11/D18) |
+| 3 | Native-Reflection-Miss → stilles null-Binden → Fehl-Installation | zentrale `ReflectionConfig`; native-IT bindet je `source.type` ein Manifest voll |
+| 4 | `outdated`-Fan-out langsam / rate-limited (60 GitHub-Calls/h unauth) | Virtual-Threads + ETag-Conditional-GETs (304 gratis) + TTL-Cache + Serve-Stale + optionaler PAT + denormalisierte Version im Index |
+| 5 | Versions-Heterogenität (calver/sha/`:latest`) → falsche Ordnung | Gleichheit/Digest statt erfundener Ordnung; optionaler `tagPattern`; sonst `UNKNOWN` |
+| 6 | Selektor blockiert nicht-interaktiv (CI, Pipe) | `System.console()==null`→`list`; jede mutierende Verb-Form hat `--yes` |
+| 7 | `install.sh`-Asset-Namen driften von JReleaser | Schema `sot-<os>-<arch>` single-sourcen; Release-Smoke im Container |
+| 8 | Destruktiver `RESET_HARD` / `rm -rf` | `--force`-Gate; `SafeFsRemover`-Denylist; eine auditierte `GitService`-Methode |
 
 ---
 
 ## 12. Aufwand (Größenordnung)
 
-Grobe Hausnummer für **eine erfahrene Person**: Phasen 0–8 summieren sich auf **~10–14 Wochen** (Skelett+Config+Exec+CLI je ~1–2 Wochen; Vault/Extensions/Bootstrap je ~1–2 Wochen inkl. Ansible-Asset-Fixes; Release ~1 Woche; Parität/Cutover ~1 Woche). Mit 2–3 Personen ab Phase 1 parallelisierbar (Config/Exec/Vault unabhängig) auf **~6–8 Wochen**. Das native-image-Gate früh (Phase 0) zu etablieren ist der wichtigste Risiko-Hebel.
+Für **eine erfahrene Person** grob **~12–16 Wochen** (Skelett/Config/Exec/CLI je ~1–2 Wo; **App-Kern + Update-Monitor + Selektor je ~1.5–2 Wo — der Wertkern**; Vault/Bootstrap/Ansible ~1.5 Wo; Install/Release ~1 Wo; Parität/Cutover ~1 Wo). Mit 2–3 Personen ab Phase 1 parallelisierbar (Config/Exec/Vault unabhängig; App-Kern → Update → Selektor seriell) auf **~7–9 Wochen**. Wichtigster Risiko-Hebel: das native-image-Gate **und** einen End-to-End-Dünnschnitt (`sot version` nativ → Install-Einzeiler) **früh** (Phase 0/8-Vorzug) etablieren.

--- a/docs/java-quarkus-rewrite-plan.md
+++ b/docs/java-quarkus-rewrite-plan.md
@@ -1,0 +1,282 @@
+# SOT — Rewrite-Plan: Bash → natives Java-CLI (Quarkus + GraalVM)
+
+> **Richtungsentscheidung:** SOT wird **komplett** von Bash auf ein **natives Java-CLI** umgebaut — **Java 21 + Quarkus 3.37+ + Picocli + GraalVM/Mandrel native-image**, als ein einzelnes selbstständiges Binary pro Plattform. Kein In-place-Bash-Refactoring mehr (der alte [`refactoring-plan.md`](./refactoring-plan.md) ist damit obsolet).
+>
+> **Grundlage:** Die bestehende Fähigkeits-/Befund-Inventur ([`refactoring-findings.md`](./refactoring-findings.md), 88 Befunde) ist die **funktionale Spezifikation** — jede heute vorhandene Fähigkeit muss im Java-CLI erhalten bleiben, und jeder der 88 Bugs muss im Neubau entweder **strukturell verschwinden** oder **bewusst gehärtet** werden. Der Ziel-Entwurf wurde von 9 Architektur-Agenten je Schicht entworfen; Quarkus/Picocli-Fakten sind gegen die aktuelle Doku (Context7) geprüft.
+
+---
+
+## 1. Zielbild in einem Satz
+
+Aus ~10 000 Zeilen dynamischem Bash wird **eine typisierte, DI-verdrahtete Java-Anwendung**, die zu **einem nativen Binary** kompiliert (schneller Start, kein JVM/Runtime nötig) und die **externen Tools (ansible, ansible-vault, terraform, git, docker) weiterhin per Prozessaufruf orchestriert**. Die Ansible-Playbooks, Docker- und Vault-Templates werden **nicht** zu Java — sie bleiben deklarative Assets, die als Classpath-Ressourcen eingebettet und zur Laufzeit von Java extrahiert und aufgerufen werden.
+
+**Warum das die 88 Bugs erschlägt:** Die überwältigende Mehrheit der Befunde sind **Artefakte des Bash-Modells** — String-Dispatch, `source`-Laden, Wort-Splitting, positionale argv-Übergabe, YAML-Parsing per `cut`/`xargs`, CI per Verzeichnis-Glob. In einem **typisierten, CDI-verdrahteten Single-Binary-Design sind diese Bug-Klassen per Konstruktion unmöglich** (siehe Mapping §5). Ein kleiner Rest bleibt echtes Engineering (native-image-Constraints, Secret-Handling, Linking) — der wird in §7/§9 explizit adressiert.
+
+**Was ausdrücklich NICHT verschwindet:** Die **Ansible-Modul-Bugs (Befund-Thema L, 10 Stück** — UFW `policy: allow`, `readVaultParameter`-Rollenname, `/etc/hosts`-Regex, Vault-Passwort-Lifecycle, OS-Abstraktion …) leben in den Playbooks weiter, weil Ansible bleibt. Sie müssen **bei der Portierung der YAML-Assets aktiv gefixt** werden — der Java-Umbau löst sie nicht auf. (Eigener Task in Phase 6.)
+
+---
+
+## 2. Ziel-Stack
+
+| Ebene | Wahl | Warum |
+|---|---|---|
+| Sprache | **Java 21** (LTS) | Records, sealed types, virtual threads, Pattern Matching — ideal für typisierte Config & Prozess-Draining |
+| Framework | **Quarkus 3.37+** | Auf GraalVM native zugeschnitten; Build-Time-DI (Arc) statt Runtime-Scanning → passt zur Closed-World-Annahme von native-image |
+| CLI | **quarkus-picocli** (Picocli) | Deklarativer Command-Baum, CDI-Injektion in Commands, `AutoComplete.GenerateCompletion` erzeugt bash/zsh-Completion aus dem lebenden Spec |
+| Config | **quarkus-jackson + jackson-dataformat-yaml** | Ein Parser (SnakeYAML-Tokenizer) statt 4 Bash-Parser; typisierte Records; `#`/Quote/Backslash-Korruption unmöglich |
+| Validierung | **quarkus-hibernate-validator** | Bean-Validation auf Config-Records (Port-Range, Namens-Pattern) |
+| Templating | **quarkus-qute** (`@CheckedTemplate`) | Typsicheres Vault-Template ohne Runtime-Reflection (native-freundlich) |
+| Native | **Mandrel/GraalVM CE 21** (`-Dnative`) | Ein Binary je Plattform; `quarkus.native.resources.includes` bettet Assets ein |
+| Build | **Maven** (+ Wrapper) | Quarkus-Primärtoolchain; `mvn …:create -Dextensions='picocli'` |
+| Release | **JReleaser** + GitHub Actions Matrix | Per-Plattform-Binaries, Checksums, SBOM (Syft), Signaturen (cosign) auf GitHub Releases |
+| Verbleibende Shell | **genau ein** `install.sh` | Erkennt OS/Arch, lädt das passende Binary + Checksum, verifiziert, verlinkt |
+
+**Bootstrap-Kommandos (verifiziert):** Projekt: `mvn io.quarkus.platform:quarkus-maven-plugin:3.37.0:create -DprojectGroupId=de.jklein.sot -DprojectArtifactId=sot -Dextensions='picocli,quarkus-jackson'`. Native-Build: `./mvnw install -Dnative` (bzw. `-Dquarkus.native.enabled=true`). Completion: `source <(sot generate-completion)`.
+
+---
+
+## 3. Ziel-Architektur
+
+### Schichten
+
+```mermaid
+graph TD
+    IN[install.sh + prebuilt native binary] --> CLI
+    subgraph CLI["cli/ — Picocli-Command-Baum (einzige Dispatch-Fläche)"]
+      ROOT["SotCommand @TopCommand + Main @QuarkusMain"]
+    end
+    CLI --> SVC
+    subgraph SVC["Services (CDI-Beans, per Konstruktor injiziert)"]
+      CFG[config/ ConfigService · SotConfig-Records]
+      EXT[extension/ CapabilityService · Provider-Strategien]
+      VLT[vault/ VaultService · Secret-Typ]
+      BOOT[bootstrap/ TaskRunner · SelfUpdate]
+      DOC[doctor/ DoctorService]
+    end
+    SVC --> PROC
+    subgraph PROC["process/ + runner/ — Prozess-Orchestrierung"]
+      PR[ProcessRunner] --> EXTTOOLS
+      GIT[GitService.gitSync]
+    end
+    subgraph RT["runtime/ — Foundation"]
+      YAML[YamlMapperProducer] 
+      PATHS[SotPaths]
+      ASSET[AssetExtractor]
+      REFL[ReflectionConfig]
+    end
+    SVC --> RT
+    PROC --> RT
+    EXTTOOLS["ansible · ansible-vault · terraform · git · docker  (externe Prozesse)"]
+    ASSET -.extrahiert.-> RES["src/main/resources: ansible/ docker/ templates/ modules/"]
+```
+
+### Package-Baum (`de.jklein.sot.*`)
+
+```
+de.jklein.sot/
+├── cli/         Picocli-Command-Baum: SotCommand(@TopCommand) · Main(@QuarkusMain) · {Bootstrap,Doctor,Vault,
+│               Runner,Extensions,Plugins,Update,Delete,Interactive}Command · SotVersionProvider · AliasExpander
+│               · AliasCheatSheetRenderer · ConsoleService/ProgressReporter · SotExitCode
+├── config/      SotConfig + {System,Ssh,Logging,Paths,Tools,Ansible,Runner,Vault}Config · ExtensionConfig
+│               · GeneratedValue(enum) · YamlConfigCodec · ConfigMerger · PlaceholderResolver · ConfigValidator
+│               · SecretStore · ConfigService   (EINE kanonische, verschachtelte, typisierte Schema-Quelle)
+├── extension/   CapabilityProvider(interface) · LocalDirectoryProvider · RemoteGitProvider · CapabilityRegistry
+│               · CapabilityService · ExtensionManifest · Capability · CapabilityType · CapabilityStateStore
+│               · ManifestParser · SafeFsRemover   (module=plugin=extension=integration → EIN Konzept)
+├── vault/       Secret(AutoCloseable char[]) · VaultPasswordSource(sealed) · SecretResolver · TransientPasswordFile
+│               · PosixGuards · AnsibleVaultRunner · SecretGenerator · VaultTemplateRenderer · VaultSecrets · VaultService
+├── process/     ProcessRunner(interface)+Impl · ProcessSpec/ProcessResult · ProgressSink/TeeSink · SecretMaterializer
+│               · GitService/GitSyncSpec · WorkspaceManager · ToolPreflight
+├── runner/      AnsiblePlaybookInvocation · AnsibleVaultInvocation · TerraformInvocation · DockerInvocation (typed arg-builder)
+├── bootstrap/   BootstrapTask(interface) + {Preflight,MaterializeAssets,DirectoryLayout,DependencyInstall,VaultReference,
+│               Finalize}Task · TaskRunner · TaskResult/BootstrapReport · InstallLayout · DependencyInstaller
+│               · GitHubReleaseClient · ChecksumVerifier · BinaryUpdater · BuildInfo
+├── doctor/      DoctorService
+└── runtime/     YamlMapperProducer · SotPaths · AssetExtractor · ReflectionConfig
+
+src/main/resources/   application.properties · config/default_config.yml · templates/vault/secrets.yml (Qute)
+                      · ansible/** · docker/** · modules/**/module.yml · assets/manifest.txt (build-generiert)
+repo-root/            pom.xml · mvnw · install.sh · jreleaser.yml · .pre-commit-config.yaml
+                      · .github/workflows/{ci,native-build,release}.yml
+```
+
+### Sieben Architektur-Prinzipien
+
+1. **Ein Dispatch-Pfad.** `CommandLine.execute(args)` in `Main`. Kein `case`, kein Registry-vs-Filesystem-Dual, keine leeren Command-Pfade. Aliase sind `@Command(aliases=…)` — ein toter Alias ist **nicht kompilierbar**.
+2. **State per Konstruktor-Injektion, nie per argv.** Der positionale `CLI_METADATA_ARGS`-Contract (R3) existiert nicht mehr; Commands bekommen `SotConfig`, `SotPaths`, `VaultService` etc. als typisierte Beans.
+3. **Ein YAML-Parser, ein Schema.** `YamlMapperProducer` liefert **den einen** Jackson-`YAMLMapper`; Config sind unveränderliche Records. Die 4 Bash-Parser und das v1/v2-Schisma sind weg.
+4. **Ein Erweiterungs-Konzept.** `CapabilityProvider` mit zwei Strategien (lokales Verzeichnis / entferntes Git-Repo) hinter **einer** Registry + einem Lifecycle. `integration`-Typ und Legacy-Kommando entfallen.
+5. **Secrets sind ein Typ, kein String.** `Secret` (AutoCloseable `char[]`, `toString()="****"`, `close()` nullt) — nie auf argv, nie im Config-YAML, nie im Log. `no_log` wird zur Typ-Eigenschaft.
+6. **Ein Install-Root, ein Binary.** Alle Pfade aus **einem** `rootDir`. Kein Doppel-Clone, kein `/opt/AAT`-Fallback, kein CLI-Sed-Patch. Der ausgeführte CLI **ist** der installierte.
+7. **Build-Time-Wahrheit.** Command-Baum, Provider-Liste, Task-Liste, Completion, Hilfe, Version werden zur **Build-Zeit** aufgelöst (Closed-World). Erweitern = ein Bean hinzufügen, nicht ein `.sh` zur Laufzeit ablegen.
+
+---
+
+## 4. Was sich **nicht** ändert (Scope-Grenze)
+
+- **Ansible / Terraform / Docker bleiben.** Sie werden als externe Prozesse orchestriert; Playbooks/Rollen/Templates sind eingebettete Assets. „Alles auf Java" heißt: **die gesamte Shell-Logik** wird Java — nicht die deklarativen Infrastruktur-Artefakte (die zu Java zu machen wäre absurd).
+- **Die Ziel-Fähigkeiten** (bootstrap, doctor, vault, runner, extensions, plugins, update/self-update, delete, help, version, interactive, completion) bleiben identisch aus Nutzersicht — nur robuster und sicherer.
+- **YAML als Config-Format** bleibt (verschachtelt), nur eben typisiert geladen.
+
+---
+
+## 5. Capability-Mapping: Bash → Java
+
+**Legende:** **[S]** = löst sich *strukturell* auf (das Java-Design macht den Befund per Konstruktion unmöglich) · **[C]** = braucht *bewusste Härtung* (Restrisiko bleibt, wird mitigiert — siehe §7/§9).
+
+| Bash-Datei / Subsystem | Ersetzt durch (Java) | Grundursache / Thema |
+|---|---|---|
+| `bin/sot` (Pfad-Bootstrap, `CLI_METADATA_ARGS`, `case`-Dispatch, `resolve_command_path`, interaktiv) | `cli.Main` + `SotCommand`-Baum + Konstruktor-Injektion | **R3** positional argv; **A** Doppel-Dispatch — [S] |
+| `lib/cli/registry.sh` (register/help/menu/completion-Gen) | `SotCommand`-Baum + `AliasCheatSheetRenderer` + `InteractiveCommand` | **A/I** Registry-vs-FS; Hilfe-Drift; leere Plugin-Pfade — [S] |
+| `lib/cli/aliases.sh` | picocli `@Command(aliases=…)` + `AliasExpander` | **F** toter `s`→setup-127-Exit; tote/Multi-Wort-Aliase — [S] |
+| `lib/cli/progress.sh`, `colors.sh` + 6 kopierte ANSI-Blöcke | `cli.ConsoleService` / `ProgressReporter` (ein Binary) | **R6** Farb-Duplikation; **E** — [S] |
+| `completions/*.{bash,zsh}` | picocli `AutoComplete.GenerateCompletion` | **R7/I** Completion-Triplikation + Drift — [S] |
+| `lib/core/yaml_parser.sh`, `parse_plugin_yaml`, `config_defaults`-Regex, `default_config{,_v2}.yml` | `YamlConfigCodec` + `YamlMapperProducer` + **ein** `default_config.yml` + `SotConfig`-Records | **R1** 4 Parser/Schema-Split; **D** flach-vs-verschachtelt; **G** `#`-Truncation/`xargs`-Korruption; **H** `PATH`/`IFS`-Key-Injection — [S] |
+| `config_defaults.sh` (`generate_dynamic_defaults`) | `PlaceholderResolver` + `GeneratedValue` + `ConfigValidator`-Gate | **F** `__GENERATE_SCRIPTS_DIR__` landet auf Disk — [S] |
+| `config_writer.sh`, `sed`, `save_plugin_state`, `overrides/` | `ConfigService.save` + `ConfigMerger` | **D** 3 Mutations-Pfade + unimplementierte Overrides — [S] |
+| `lib/plugins/manager.sh` + `lib/extensions/manager.sh` + `commands/extensions.sh` (3 Manager, 4 Begriffe) | `CapabilityRegistry` + `CapabilityService` + `CapabilityProvider`-Strategien | **R2/B** vier Begriffe, drei disjunkte Subsysteme — [S] |
+| `modules/*/module.yml`, `parse_plugin_yaml`, `PLUGIN_DEPENDENCIES` | `ExtensionManifest` + `ManifestParser`; topologische Dep-Auflösung | **B** Schema-vs-Parser; ignorierte Deps; Typ-Taxonomien — [S] |
+| `_update_config_value` / `save_plugin_state` (persistiert nie) | `CapabilityStateStore` | **B/F** Persistenz-Lüge — [S] |
+| `commands/vault.sh`, `roles/{vault,read_vault_parameter}`, `vault_template.j2` | `VaultService` + `AnsibleVaultRunner` + `Secret` + `TransientPasswordFile` + `VaultTemplateRenderer` | **R5/H** Secret auf argv, Klartext in Config, persistente `vault_pass.txt`, Debug-Dump, schwache Defaults, fehlende view/rekey — [S]; Symlink-Race, tmpfs-Garantie, Secure-Delete — [C] |
+| `commands/runner.sh` (ansible/terraform, tee, sync_repo), `trigger.sh` | `ProcessRunner` + `runner.*Invocation` + `TeeSink` + `ToolPreflight` | **R3/R6** positional argv + duplizierter Arg-Bau — [S] |
+| Git-Clone (`init.sh`/`tasks.sh`), `manager.sh` fetch+pull, `update.sh` `reset --hard`+`clean` | `GitService.gitSync(GitSyncSpec, PULL/RESET_HARD)` | **R6** 4 Git-Sync-Stellen; **G** ungeschützter Reset — [S]; RESET_HARD-Datenverlust — [C] |
+| `bootstrap/init.sh` curl\|bash Selbst-Clone + re-exec + re-clone | `install.sh` (dünn) + Prebuilt-Binary + `InstallLayout` | **R4** zwei Roots; **C** Selbst-Clone/CLI-Edit/`SETUP_DIR` — [S]; Root-Default-Wahl — [C] |
+| `bootstrap/{tasks,runner,args_parser}.sh` | `BootstrapTask`-Beans + `TaskRunner` + `BootstrapReport` | **F** „immer erfolgreich"-Lüge; unparste `$1/$2` — [S] |
+| `bootstrap/dependencies.sh` | `DependencyInstaller`-Strategien | **F** still verworfene `-tools`-Tokens — [S] |
+| `commands/maintenance/update.sh` | `SelfUpdateCommand` + `BinaryUpdater` + `ChecksumVerifier` + `GitHubReleaseClient` | **G/H** ungeschützter Reset; unverifiziertes Update — [S]; Cross-Device-Move, TLS/CA — [C] |
+| `commands/maintenance/delete.sh` (safe-delete, vault-backup) | `SafeFsRemover` + `PathGuardTest`-Denylist | **R5/H** `rm -rf` auf Config-Pfade + sed-Injection; Secret in `/tmp/BACKUP_INFO.txt` — [S] |
+| `lib/init.sh` Source-Loader/Doppel-Sourcing, `SOT_ROOT`-Probing | `runtime.SotPaths` + Arc-Bean-Graph | **R4/E** Load-Modell, Doppel-Source, `SCRIPT_ROOT`-Drift — [S] |
+| `modules/ansible/**`, Templates, Docker (loser Baum) | `src/main/resources/**` + `AssetExtractor` (+ `assets/manifest.txt`) | Asset-Embedding für native — [S]; Manifest-Vollständigkeit — [C] |
+| **`modules/ansible/roles/*` INHALT (UFW, Rollenname, hosts-Regex, Vault-Lifecycle, OS-Abstraktion)** | **portierte, gefixte Ansible-Assets** (bleiben YAML) | **Thema L (10 Befunde)** — **NICHT [S]/[C], sondern manuell zu fixen** ⚠️ |
+| `tests/*.sh` + Mock-`ansible-vault` | `@QuarkusTest` + `RecordingProcessRunner` + `FakeToolPathResource` + `ConfigRoundtripTest` + `VaultBehaviorTest` | **K** grep-String-Tests, `set -e`-Counter, Null-Coverage, bash≥4/macOS-3.2 — [S] |
+| `.github/workflows/{test,lint,security,deploy}.yml`, `.pre-commit-config` | `ci.yml` + `native-build.yml` + `release.yml` + `jreleaser.yml` | **R7** False-Green `security.yml` `\|\| true`, `ci/`-Drift; **I** — [S]; native musl/exec — [C] |
+
+**Bilanz der 88 Befunde:** ~geschätzt **60+ lösen sich strukturell [S]** (Themen A, B, D, E, F, I, J, K + R1/R2/R3/R4-Layout/R6/R7). **~8–10 brauchen bewusste Härtung [C]** (native Reflection/Ressourcen, Linking, Secret-Härtung, Legacy-Migration, Self-Replace, Manifest-Vollständigkeit). **10 (Thema L) lösen sich gar nicht** — sie müssen in den portierten Ansible-Assets **aktiv gefixt** werden (Phase 6).
+
+---
+
+## 6. Native-Image-Constraints (die echten Fallstricke)
+
+| Bereich | Was zu tun ist |
+|---|---|
+| **Reflection** | `@RegisterForReflection` auf **alle** Jackson-Records (`SotConfig` + Sektionen, `ExtensionManifest`, `VaultSecrets`, GitHub-Release-DTOs) **zentral in `ReflectionConfig`** — sonst Runtime-Fehler „missing constructor". Picocli-`IVersionProvider`/`IHelpSectionRenderer`/`IExitCodeExceptionMapper`/`GenerateCompletion` ebenfalls registrieren. |
+| **Ressourcen** | `quarkus.native.resources.includes=ansible/**,docker/**,templates/**,config/**,modules/**,assets/manifest.txt` — sonst fehlen die Assets im Binary. Ein natives Binary kann Classpath-Ressourcen **nicht `Files.walk`en** und **nicht direkt exec**en → `AssetExtractor` iteriert das build-generierte `assets/manifest.txt` und kopiert jede Ressource (idempotent, content-hash, 0700) in ein beschreibbares Verzeichnis, **bevor** ProcessBuilder ansible/git/docker aufruft. |
+| **Closed-World** | Kein `Class.forName`, kein Runtime-Scanning. CDI-Beans, Command-Baum, `@All List<CapabilityProvider>`, `@All List<BootstrapTask>` werden zur Build-Zeit aufgelöst. |
+| **Build- vs Runtime-Init** | `$SOT_HOME`/Env zur **Laufzeit** lesen (`SotPaths @ApplicationScoped`); `YAMLMapper` build-time via `@Produces`; Version/Commit als generierte `BuildInfo`-Ressource (kein Runtime-`git`); `SecureRandom` `--initialize-at-run-time`. |
+| **Charsets** | `quarkus.native.add-all-charsets=true` + UTF-8 `file.encoding` (deutsche Ausgabe, Non-ASCII-Vault) — im Native-Smoke-Test prüfen. |
+| **Prozess-Exec + Linking ⚠️** | `ProcessBuilder` nutzt `posix_spawn`. **ABER: voll-statische (musl) native Images können nicht fork/exec** — und das ganze Tool ruft externe Prozesse auf. Linux daher **mostly-static (glibc) oder dynamisch**, **nicht** `--static --libc=musl`. CI muss echten Subprozess-Aufruf aus dem gebauten Binary beweisen. |
+| **TLS (Self-Update)** | JDK-`HttpClient` über TLS braucht `quarkus.ssl.native=true` + eingebetteten CA-Truststore (mit Override). SHA-256 via `MessageDigest` ist Default. |
+
+---
+
+## 7. Offene Entscheidungen (vor bzw. in Phase 0 zu fixieren)
+
+Der Multi-Agenten-Entwurf hat echte Widersprüche zwischen den Schichten aufgedeckt. Empfehlung je Zeile; die mit ⚠️ sind **load-bearing**.
+
+| # | Entscheidung | Empfehlung | Anmerkung |
+|---|---|---|---|
+| **D1** ⚠️ | **Native-Linking:** static-musl vs mostly-static-glibc | **mostly-static glibc / dynamisch** | **Keine echte Wahl, sondern Korrektheits-Constraint:** static-musl kann nicht fork/exec → Tool wäre kaputt. Zwei Schicht-Entwürfe hatten fälschlich musl-static gewählt. |
+| **D2** | **Root-Package / groupId** | `de.jklein.sot` (= groupId) | Agenten schlugen 5 verschiedene vor; auf einen normiert. |
+| **D3** | **Install-Root + Symlink** | Root `/opt/sot`, Symlink `/usr/local/bin/sot`; `SotPaths` & `InstallLayout` zu **einem** Pfadmodell mergen | Löst R4; bestätige die Pfadwahl. |
+| **D4** | **Vokabular „Capability" vs „Extension"** | **Extension** durchgängig (User-Term = `sot extensions`/`ex`); interne Klassen konsistent benennen | Aktuell mischt der Entwurf `Capability*`-Klassen mit `extension/`-Package. |
+| **D5** | **`ProcessRunner`** Interface vs konkret | **Interface + `ProcessRunnerImpl`** | Tests brauchen das Interface (`@InjectMock`/`@Alternative`). |
+| **D6** | **Geteilte Beans deduplizieren** | je **ein** `YAMLMapper`, **ein** `Secret`-Typ, **ein** `SecretMaterializer`, **ein** `AssetExtractor`, **ein** `ProcessRunner` | Mehrere Schichten beanspruchten dieselbe „single source" — genau einmal implementieren. |
+| **D7** | **macOS-Scope** | **v1: Linux nativ (primär); macOS nur JVM/Dev.** Natives macOS-Binary + Vault-tmpfs-Strategie später | macOS hat kein `/dev/shm`; native Static-Linking ist ohnehin Linux. **Bitte bestätigen.** |
+| **D8** | **Self-Update** | Beide: `install.sh` (Erstinstallation) + `sot self-update` (Upgrade), **beide** verifizieren Checksum **+ cosign** | Angleichen (eine Schicht hatte nur `shasum`). |
+| **D9** | **Legacy-Config-Migration** | Einmal-Migrations-Reader (`FAIL_ON_UNKNOWN=false` + Key-Mapping) → schreibt kanonisches Schema, dann strikt | Nur nötig, falls **produktive SOT-Installationen im Feld** existieren — **bitte bestätigen** (sonst Greenfield). |
+| **D10** | **`module.yml` `apiVersion`** | Von Anfang an mitführen (warn-not-fail-Fenster) | Deckt zugleich D9-Manifest-Evolution ab. |
+
+---
+
+## 8. Migrations-Phasen (Greenfield-Neubau, „Strangler" bis Parität)
+
+Neubau in einem neuen Maven-Modul, **Fähigkeit für Fähigkeit**, jede Phase eine reviewbare PR mit **Abnahme-Gate**. Der alte Bash-Baum bleibt bis Phase 8 (Cutover) lauffähig als Referenz. Aufwand: **S** ≤ 2 Tage, **M** ≈ 3–5 Tage, **L** ≈ 1–2 Wochen (eine Person).
+
+### Phase 0 — Projekt-Skelett & Foundation *(L · blockiert alles · fixiert D1–D6)*
+Maven/Quarkus/Java-21-Setup; Package-Baum; `quarkus-picocli`-Hello-World `sot version`; `YamlMapperProducer`, `SotPaths`, `AssetExtractor`, `ReflectionConfig`, `application.properties` (resources.includes, add-all-charsets, Mandrel-Image); dünnes `install.sh`-Stub; `ci.yml` mit **JVM-Verify + einem linux-amd64-Native-Smoke** (`sot version` als Native-Binary). **Linking-Entscheidung D1 hier verifizieren** (Native-Binary ruft `git --version` erfolgreich auf).
+**Gate:** `sot version` läuft als natives Binary in CI; Native-Binary kann einen externen Prozess starten (beweist mostly-static-glibc).
+
+### Phase 1 — Config-Kern *(L · hängt an 0 · löst R1/D)*
+`SotConfig`-Records (verschachtelt), `YamlConfigCodec`, `ConfigMerger`, `PlaceholderResolver` + `GeneratedValue`, `ConfigValidator`, `SecretStore` (0600-Referenz statt Secret-Feld). `default_config.yml` als einzige kanonische Vorlage.
+**Gate:** `ConfigRoundtripTest` (`load(save(cfg))==cfg`, Golden-File, jqwik-Properties inkl. `#`/Quote/CRLF); Native-IT lädt `default_config.yml` und bindet alle Sektionen.
+
+### Phase 2 — Prozess-/Exec-Engine *(M · hängt an 0 · löst R6/R3-argv)*
+`ProcessRunner`(Interface)+Impl mit Virtual-Thread-Draining, `ProcessSpec/Result`, `TeeSink`, `GitService.gitSync` (PULL/RESET_HARD, `--force`-gated), `SecretMaterializer` (0600-Datei/stdin/env, nie argv), `WorkspaceManager`, `ToolPreflight`, typisierte `runner.*Invocation`-Records.
+**Gate:** Tests mit `RecordingProcessRunner` (kein echtes ansible/git); Native-Smoke ruft echtes `git`/`echo` auf (härtet D1 endgültig ab).
+
+### Phase 3 — CLI-Gerüst & Dispatch *(L · hängt an 1+2 · löst A/F-Dispatch, R3)*
+`SotCommand`-Baum, `Main`, globale Optionen (`scope=INHERIT`), Hilfe/Version, `GenerateCompletion`, `@Command(aliases=…)` + `AliasExpander`, `InteractiveCommand`, `SotExitCode`, `ConsoleService`. Commands als dünne Schalen, die (teils gestubte) Services aufrufen.
+**Gate:** `@QuarkusMainTest` e2e über `sot help`/`--help`/`generate-completion`/Exit-Codes; Completion deckt exakt den Command-Baum.
+
+### Phase 4 — Vault & Security *(L · hängt an 1+2 · löst R5/H)*
+`Secret`(AutoCloseable), `VaultPasswordSource`(sealed)+`SecretResolver`, `TransientPasswordFile`+`PosixGuards` (tmpfs-verifiziert, fail-loud), `AnsibleVaultRunner` (Passwort via Datei/stdin), `SecretGenerator`, Qute-`secrets.yml`, `VaultService` (init/view/edit/rekey/read — view+rekey **neu funktional**), `VaultCommand`.
+**Gate:** `VaultBehaviorTest` (kein Secret in argv/`ps`, 0600-tmpfs-Datei, nach Nutzung weg); Container-IT: echter `ansible-vault` encrypt→decrypt-Roundtrip.
+
+### Phase 5 — Extensions/Capability *(L · hängt an 1+2+3 · löst R2/B)*
+`CapabilityProvider` + `LocalDirectoryProvider`/`RemoteGitProvider`, `CapabilityRegistry` (`@All`), `CapabilityService` (list/info/install/remove/enable/disable/sync/run), `ExtensionManifest`+`ManifestParser` (apiVersion), `CapabilityStateStore` (echte Persistenz), `SafeFsRemover`, `ExtensionsCommand`/`PluginsCommand`.
+**Gate:** `ExtensionManagerTest` — install/enable/sync/**persist**-Roundtrip über beide Provider; kaputtes `module.yml` schlägt bei Discovery fehl.
+
+### Phase 6 — Bootstrap, Runner & Ansible-Assets *(L · hängt an alle Services · löst C/F + Thema L)*
+`BootstrapTask`-Pipeline + `TaskRunner`/`BootstrapReport` (ehrlicher Exit), `DependencyInstaller`-Strategien, `InstallLayout`, `RunnerCommand` verdrahtet die Invocation-Records, `AssetExtractor` der eingebetteten `ansible/`. **Zusätzlich: die portierten Ansible-Assets fixen** — UFW `deny`, Rollenname `read_vault_parameter`, `/etc/hosts`-Regex, Vault-Passwort-Lifecycle, OS-Abstraktion (`package` + `when: ansible_os_family`), `ansible_facts`-Missbrauch, Docker aus Trigger lösen (**Thema L**).
+**Gate:** `sot bootstrap` bringt einen Wegwerf-Container in definierten Zustand; `ansible-lint` grün; Vault-encrypt→decrypt-Roundtrip in der Ansible-Rolle grün.
+
+### Phase 7 — Self-Update, Packaging & Release *(L · hängt an 0 + App · löst R7)*
+`GitHubReleaseClient`+`ChecksumVerifier`+`BinaryUpdater` (Sibling-Temp → verify → `ATOMIC_MOVE` → re-exec), JReleaser-Multi-Arch (linux amd64/arm64), `install.sh` vollständig (Checksum + cosign), `release.yml` (Tag `v*`), `native-build.yml`-Matrix, `.pre-commit-config` (Spotless/shellcheck-für-install.sh/yamllint/ansible-lint/gitleaks).
+**Gate:** Getaggter Release erzeugt verifizierte Per-Plattform-Binaries; `install.sh` installiert sie; `sot self-update`-Roundtrip funktioniert.
+
+### Phase 8 — Parität, Cutover & Legacy-Migration *(M · final)*
+Volle Testabdeckung (extensions/bootstrap/config/doctor/maintenance); Legacy-`config.yaml`-Migrations-Reader (D9); **die 88-Befund-Regressions-Checkliste abarbeiten** (jedes [S] nachweislich weg, jedes [C] nachweislich mitigiert, Thema-L-Fixes verifiziert); alten Bash-Baum entfernen; README/Docs neu schreiben.
+**Gate:** Paritäts-Checkliste 100 %; Bash entfernt; `refactoring-findings.md` vollständig abgehakt.
+
+### Sequenz
+
+```
+Phase 0 (Skelett/Foundation, fixiert D1–D6)
+   └─► Phase 1 (Config) ─┐
+   └─► Phase 2 (Exec) ───┤
+                         ├─► Phase 3 (CLI) ─► Phase 5 (Extensions)
+                         ├─► Phase 4 (Vault)          │
+                         └─► Phase 6 (Bootstrap+Runner+Ansible-Assets)
+Phase 7 (Release/Self-Update)  ── ab Phase 0 vorbereitbar, voll ab lauffähiger App
+Phase 8 (Parität/Cutover/Migration)  ── ganz zuletzt
+```
+**Kritischer Pfad:** 0 → 1/2 → 3 → 5/6 → 8. Phase 4 parallel ab 2; Phase 7 parallel ab 0.
+
+---
+
+## 9. Verifikationsstrategie
+
+- **Drei Test-Tiers:** (1) `@QuarkusTest` JVM-Komponententests mit gemocktem `ProcessRunner` (nie echtes ansible/git); (2) `@QuarkusMainTest` CLI-e2e über `QuarkusMainLauncher`; (3) `@QuarkusMainIntegrationTest` **native** Black-Box-Smoke mit `FakeToolPathResource` (echte Fake-Tools auf PATH).
+- **Native-Gate ist Pflicht:** Ein natives IT lädt Config, parst jedes echte `module.yml`, fährt einen Runner-Dry-Run — verwandelt Reflection-/Ressourcen-Fehler von Runtime-Überraschungen in gefangene CI-Fehler.
+- **Paritäts-Checkliste** gegen `refactoring-findings.md`: jeder der 88 Befunde bekommt einen Status (dissolved-[S] / hardened-[C] / ansible-fixed-L) mit Test- oder Code-Nachweis. Das ist das Abnahmekriterium für Phase 8.
+- **Verhaltens- statt Text-Tests** für Security (kein Secret in argv via `ps`; 0600-tmpfs).
+- **CI failt hart** (kein `|| true`); SonarCloud-Quality-Gate als Required-Check.
+
+---
+
+## 10. Risiken & Gegenmaßnahmen (Top 8)
+
+| # | Risiko | Gegenmaßnahme |
+|---|---|---|
+| 1 ⚠️ | **static-musl kann nicht fork/exec** (architektur-brechend) | **mostly-static glibc/dynamisch** bauen; libc im Asset-Namen; CI beweist Subprozess-Exec aus dem Binary vor jedem Release (D1) |
+| 2 | Native Reflection/Ressourcen-Miss zeigt sich erst zur Laufzeit | Zentrale `ReflectionConfig`; Pflicht-Native-IT (Config-Load + alle `module.yml` + Runner-Dry-Run); Build-Assert, dass jeder `resources.includes`-Glob + `manifest.txt`-Eintrag auflöst |
+| 3 | Secret-Restexposition (Heap-Copy, unsicheres Secure-Delete) | tmpfs(RAM)+0600+sofort-unlink+SecureRandom-Name+`O_EXCL`/`NOFOLLOW` (killt Symlink-Race 165); Overwrite = Best-Effort; try-with-resources; Core-Dumps aus; Restrisiko dokumentiert |
+| 4 | tmpfs fehlt/ist Disk (Container, macOS) → Passwort auf Platte | `PosixGuards` verifiziert echtes tmpfs und **failt laut** statt still zu persistieren; gatet zugleich macOS (D7) |
+| 5 | Legacy-`config.yaml` bricht striktes Binding | Einmal-Migrations-Reader (`FAIL_ON_UNKNOWN=false` + Key-Mapping) → kanonisch umschreiben, dann strikt (D9) |
+| 6 | Destruktiver `RESET_HARD`-Datenverlust (aus `update.sh`) | `SyncMode.RESET_HARD` nur mit `--force`; Default `PULL`; eine auditierte `GitService`-Methode |
+| 7 | Self-Replace scheitert Cross-Device/EACCES; TLS/CA bricht Download | Temp ins Zielverzeichnis, Checksum+cosign vor `ATOMIC_MOVE`, klare Fallback-Meldung bei EXDEV/EACCES; CA eingebettet + Override |
+| 8 | Lange/flaky Multi-Arch-Native-Builds, Mandrel-Drift | PRs: JVM-Verify + 1× linux-amd64-Smoke; volle Matrix nur auf Tag (`fail-fast:false`); Mandrel-Version + Builder-Image-Tag pinnen; Renovate-Bumps müssen das Native-Gate bestehen |
+
+---
+
+## 11. Abhängigkeiten (Kurzliste)
+
+**Runtime:** `quarkus-picocli`, `quarkus-arc`, `quarkus-jackson`, `jackson-dataformat-yaml` (SnakeYAML), `quarkus-hibernate-validator`, `quarkus-qute`.
+**Test:** `quarkus-junit5`, `quarkus-junit5-mockito`, `quarkus-jacoco`, `assertj-core`, `jqwik`.
+**Build/Release:** `quarkus-maven-plugin`, `jreleaser-maven-plugin`, `spotless-maven-plugin`, `jacoco-maven-plugin`, `sonar-maven-plugin`; Actions: `graalvm/setup-graalvm@v1` (Mandrel 21, gepinnt), `anchore/sbom-action` (Syft), `sigstore/cosign`.
+
+---
+
+## 12. Aufwand (Größenordnung)
+
+Grobe Hausnummer für **eine erfahrene Person**: Phasen 0–8 summieren sich auf **~10–14 Wochen** (Skelett+Config+Exec+CLI je ~1–2 Wochen; Vault/Extensions/Bootstrap je ~1–2 Wochen inkl. Ansible-Asset-Fixes; Release ~1 Woche; Parität/Cutover ~1 Woche). Mit 2–3 Personen ab Phase 1 parallelisierbar (Config/Exec/Vault unabhängig) auf **~6–8 Wochen**. Das native-image-Gate früh (Phase 0) zu etablieren ist der wichtigste Risiko-Hebel.

--- a/docs/java-quarkus-rewrite-plan.md
+++ b/docs/java-quarkus-rewrite-plan.md
@@ -1,394 +1,298 @@
-# SOT — Rewrite-Plan: Bash → natives Java-CLI (Quarkus + GraalVM), als dynamischer App-Manager
+# SOT — Rewrite-Plan: natives Java-CLI (Quarkus + GraalVM), Nix-Substrat, dynamischer App-Manager
 
-> **Was gebaut wird:** SOT wird komplett von Bash auf ein **natives Java-CLI** umgebaut — **Java 21 · Quarkus 3.37+ · Picocli · GraalVM/Mandrel native-image**, ein selbstständiges Binary pro Plattform, **gebaut mit Gradle**, mit einem **Justfile** als Entwickler-Frontend.
+> **Was gebaut wird:** SOT wird komplett von Bash auf ein **natives Java-CLI** umgebaut — **Java 21 · Quarkus 3.37+ · Picocli · GraalVM/Mandrel native-image**, gebaut mit **Gradle** + **Justfile**, ausgeliefert als **Nix-Flake**.
 >
-> **Wozu:** SOT ist ein **dynamischer App-Manager für die eigene Umgebung** — ein CLI-**App-Selektor**, mit dem der Owner seine **eigenen Anwendungen** installiert, aktualisiert und **überwacht** (welche App ist veraltet), plattform-/quellenübergreifend, **ohne den Toolneubau** (neue App = neue Manifest-Datei im Katalog).
+> **Vier Säulen:**
+> 1. **Dynamischer App-Manager** — ein CLI-App-Selektor, der eigene Anwendungen installiert/updatet und **überwacht** (was ist veraltet), über alle Apps hinweg, ohne Toolneubau.
+> 2. **100 % Nix als Substrat** — die CLI installiert Nix und zieht **alle** Abhängigkeiten und Apps über **Nix** (kein apt/brew). Reproduzierbar.
+> 3. **Cross-Platform** — nativ auf **Linux + macOS**, **Windows via WSL2 (NixOS-WSL)**.
+> 4. **Ein Bootstrap-Befehl pro Plattform** — `curl … /cli/install.sh | bash` (Linux/macOS) bzw. `irm …/cli/install.ps1 | iex` (Windows), von **deiner** Domain.
 >
-> **Grundlagen-Doku (Evidenz):** [`refactoring-findings.md`](./refactoring-findings.md) (88 Ist-Befunde = funktionale Spec), [`java-quarkus-design-brief.md`](./java-quarkus-design-brief.md) (Schicht-Entwurf), [`java-quarkus-appmanager-brief.md`](./java-quarkus-appmanager-brief.md) (App-Manager + Delivery). Der alte Bash-in-place-Plan [`refactoring-plan.md`](./refactoring-plan.md) ist **superseded**.
+> **Evidenz:** [`refactoring-findings.md`](./refactoring-findings.md) (88 Ist-Befunde = funktionale Spec), [`java-quarkus-design-brief.md`](./java-quarkus-design-brief.md) · [`java-quarkus-appmanager-brief.md`](./java-quarkus-appmanager-brief.md) · [`java-quarkus-nix-substrate-brief.md`](./java-quarkus-nix-substrate-brief.md) (Schicht-Entwürfe). Alter Bash-Plan [`refactoring-plan.md`](./refactoring-plan.md) = **superseded**.
 
 ---
 
-## 1. Die zwei Kern-Anforderungen (und wie der Plan sie erfüllt)
+## 1. Die vier Kern-Anforderungen → Umsetzung
 
-| # | Anforderung | Umsetzung |
+| # | Anforderung | Umsetzung (Kurz) |
 |---|---|---|
-| **A** | **Ein-Befehl-Installation via GitHub-URL** auf Debian/Linux — Nutzer geben genau **einen** Bash-Befehl ein. | `curl -fsSL https://raw.githubusercontent.com/NiklasJavier/SOT/<ref>/install.sh \| bash` lädt das passende **vorgebaute native Binary** aus GitHub Releases, verifiziert (SHA-256 + cosign) und legt `sot` auf den PATH. Kein JVM, kein Build beim Nutzer. → §3 |
-| **B** | **Dynamischer App-Manager**: App-Selektor im CLI, eigene Anwendungen installieren/updaten **über alle Apps hinweg**, mit **Update-Überwachung**, „tief dynamisch". | Apps sind **deklarative Manifeste** (`app.yml`) aus einem **konfigurierbaren Katalog-Repo**, orchestriert von einem festen Satz **Install-Strategien**. Neue App = Manifest hinzufügen, **kein Rebuild**. Ein `UpdateMonitor` prüft quellenübergreifend „veraltet?". → §2 |
+| **A** | Ein-Befehl-Install via URL, alle Plattformen | Linux/macOS: `curl -fsSL https://<host>/cli/install.sh \| bash`. Windows: `irm https://<host>/cli/install.ps1 \| iex`. Beide bootstrappen Nix bzw. WSL2+NixOS und `nix profile install` das CLI. → §3 |
+| **B** | Dynamischer App-Manager mit Update-Überwachung | Apps = deklarative `app.yml`-Manifeste aus konfigurierbarem Katalog; feste Install-/Version-Strategien; `sot app`-Selektor; `sot app outdated`. Neue App = Manifest, **kein Rebuild**. → §2 |
+| **C** | **100 % Nix**, keine apt/brew — Deps & Apps über Nix | `NixService` (einziges Gateway zu `nix`), eine reproduzierbare **Toolchain-Flake** (pinned nixpkgs + `flake.lock`) im dedizierten SOT-Profil; Apps via `nix profile install`. `apt-deb`/`DependencyInstaller` gelöscht. → §4 |
+| **D** | Cross-Platform Linux/macOS nativ, Windows via VM | SOT selbst = **Nix-Flake** (4 Systeme), Binary-Cache liefert das vorgebaute native Binary. Windows = **NixOS-WSL** + Windows-`sot.exe`-Shim → `wsl -e sot`. → §5 |
 
-**Der architektonische Kniff (löst „tief dynamisch" vs. GraalVM-Closed-World):** GraalVM native-image ist **Closed-World** — kein Laden neuer Java-Klassen zur Laufzeit. „Tief dynamisch" heißt daher **nicht** „Java-Plugins nachladen", sondern: die **Menge der Strategien** (git/docker-compose/release-binary/deb/script) ist fest **einkompiliert**; **welche Apps existieren** und ihre gesamte Konfiguration sind **100 % Laufzeit-Daten** (Manifeste aus git/HTTP). So ist das System voll dynamisch **ohne** die Closed-World-Annahme zu verletzen.
+**Der Kniff „tief dynamisch" trotz GraalVM-Closed-World:** GraalVM native lädt keine Java-Klassen zur Laufzeit. Also: die **Menge** der Strategien (nix, nix-flake, docker-compose, git-repo, script) und der Version-Resolver ist fest **einkompiliert**; **welche Apps/Tools** existieren + ihre Config sind **100 % Laufzeit-Daten** (Manifeste aus git/HTTP, Nix-Attribute/Flake-Refs). Dynamik ohne Closed-World-Bruch.
 
 ---
 
-## 2. Kern-Zweck: Der dynamische App-Manager
+## 2. App-Manager (Anforderung B) — jetzt Nix-first
 
-### 2.1 Zwei getrennte Achsen (das zentrale Designprinzip)
+### 2.1 Zwei getrennte Achsen
+- **Katalog (WOHER, Laufzeit-Daten):** `CatalogSource` = `git` / `http-index` / `bundled`. Neue App = `app.yml` hinzufügen.
+- **Strategie (WIE, einkompiliert):** `InstallStrategy`-Beans nach `AppSourceType`. **Nix-first.**
 
-Bash vermischte „**woher** kommt eine App-Definition" mit „**wie** wird sie installiert". Java trennt sie:
+**`AppSourceType` = `NIX` · `NIX_FLAKE` · `GIT_REPO` · `DOCKER_COMPOSE` · `SCRIPT`** *(neu: NIX/NIX_FLAKE; entfernt: `APT_DEB`, und `GITHUB_RELEASE_BINARY` — eigene Apps fallen unter `NIX_FLAKE`).*
 
-- **`CatalogSource` — WOHER (100 % Laufzeit-Daten).** Ein konfigurierbarer Satz Kataloge: `git` (dein Katalog-Repo), `http-index` (ein Index-URL), `bundled` (eingebettete Default-Apps). Zur Laufzeit gefetcht, nach `priority` gemerged. Neue App = `app.yml` in den Katalog legen.
-- **`InstallStrategy` — WIE (fest einkompiliert).** Fünf CDI-Beans hinter **einem** Interface: `git-repo`, `docker-compose`, `github-release-binary`, `apt-deb`, `script`. Neue Strategie = Bean hinzufügen (Rebuild). Jede delegiert an die geteilte `ProcessRunner`/`GitService`/`GitHubReleaseClient` — kein Neuimplementieren von exec.
-
-Das **subsumiert die alte Extension/Plugin-Schicht**: eine „Extension" (AAT/TID) ist jetzt einfach eine App mit einem `runner:`-Block. `CapabilityService`→`AppService`, `CapabilityStateStore`→`InstalledAppStore`, `module.yml`→`app.yml`. Ein Vokabular.
-
-### 2.2 Das App-Manifest (`app.yml`) — die deklarative Einheit
-
+### 2.2 `app.yml` — Nix-Quellen
 ```yaml
-apiVersion: sot.dev/v1
-kind: App
-id: grafana                     # katalog-eindeutige, stabile ID
-name: Grafana
-description: Monitoring dashboards
-category: observability
-labels: [monitoring, ui]
-source:                         # WIE installieren → wählt die InstallStrategy
-  type: docker-compose          # git-repo | docker-compose | github-release-binary | apt-deb | script
-  repoUrl: https://github.com/owner/grafana-stack
-  ref: v10.4.0
-  composeFile: docker-compose.yml
-version:                        # WIE „neueste Version" bestimmen → wählt den VersionResolver
-  strategy: docker-image        # github-release | git-tag | docker-image | apt | static | script
-  constraint: '>=10.0.0 <11.0.0'
-  tagPattern: '^v(\d+\.\d+\.\d+)$'
-requires:                       # topologisch vor der Installation aufgelöst
-  tools: [docker]
-  apps:  [prometheus]
-  os:    [debian, ubuntu]
-install:
-  path: '{appsRoot}/grafana'    # via SotPaths getemplatet
-  env:  { GF_PORT: '3000' }
-  hooks: { postInstall: scripts/post.sh }
-runner:                         # OPTIONAL — vorhanden ⇒ App ist eine AAT/TID-artige Ansible-Extension
-  playbooks: [site.yml]
+# nixpkgs-Attribut (System-Tool/CLI)
+source: { type: nix, attr: opentofu, nixpkgs: github:NixOS/nixpkgs/nixos-24.11, mode: profile }  # mode: profile|build
+version: { strategy: nix, constraint: '>=1.7.0 <2.0.0' }        # auf attr .version wenn SemVer
+---
+# eigene App als Flake (inkl. SOT-Katalog-Apps)
+source: { type: nix-flake, flakeRef: github:NiklasJavier/grafana-stack, attr: default, rev: v10.4.0 }
+version: { strategy: nix-flake }   # vergleicht installierte locked rev vs. `nix flake metadata --json` .locked.rev
+---
+# docker-compose-Stack — docker selbst kommt AUS Nix
+source: { type: docker-compose, repoUrl: https://github.com/NiklasJavier/monitoring, composeFile: docker-compose.yml }
+requires: { tools: [docker] }      # NixToolProvisioner stellt docker via Nix bereit
 ```
 
-Ein Katalog listet seine Apps in einer `index.yml` (`id → manifest-Pfad + denormalisierte Version` für schnelles Listing). Der installierte Zustand lebt getrennt in `installed.yml` (0600, atomar geschrieben): installierte Version, Quelle, Pfad, Pin-Status, Checksum.
+### 2.3 Install & Update über Nix
+- Zwei neue `InstallStrategy`-Beans: **`NixpkgsInstallStrategy`** (`NIX`) und **`NixFlakeInstallStrategy`** (`NIX_FLAKE`), beide über `NixProfileManager`.
+- **Pro-App-Profil** `{stateRoot}/profiles/<appId>` (eigene Generationen, atomarer Rollback, sauberes Remove); `<profile>/bin/*` → gemeinsames PATH-Dir. `install`=`nix profile install --profile p <installable>`, `update`=`nix profile upgrade`, `remove`=`nix profile remove` + Symlinks/Dir weg. Alles zieht aus dem **Binary-Cache** (Download, kein Compile).
+- **Pin/Update:** `NIX_FLAKE` via `flake.lock`; `NIX` via nixpkgs-Rev; EXACT-Pin → eingefrorener Rev in `installed.yml`, RANGE → Rev nur solange `attr.version` in der Constraint bleibt.
 
-### 2.3 Die eine Install-Strategie-Schnittstelle
+### 2.4 Update-Überwachung über Nix
+- **`UpdateStrategy` = `NIX` · `NIX_FLAKE` · `GITHUB_RELEASE` · `GIT_TAG` · `DOCKER_IMAGE` · `STATIC` · `SCRIPT`** *(neu NIX/NIX_FLAKE; entfernt APT).*
+- **`NixVersionResolver`** liest installierte locked rev aus `nix profile list --json`, Upstream aus `nix flake metadata <ref> --json` (`.locked.rev`) bzw. `nix eval --raw <nixpkgsRef>#<attr>.version` → faltet in `UpdateMonitorService.checkAll()` (Virtual-Thread-Fan-out, `VersionCache` mit TTL/Serve-Stale). Fehler je App → `UNKNOWN`.
+- Kein Daemon: `sot bootstrap` legt einen systemd-Timer → `sot app check --quiet --notify`; `sot app outdated`/`status` lesen den Cache offline.
 
+### 2.5 Selektor & Command-Surface
+`sot app` (Aliase `apps`/`a`) — bare auf TTY = interaktiver zeilenorientierter Selektor (kein JLine, native-sicher), in einer Pipe = `list`. Verben: `list/search/info/install/update/outdated/status/check/remove/pin/unpin/catalog`. `sot ex` = lebender Filter `role=runner` (AAT/TID). Global: `--json/--yes/--no-color/--catalog/--dry-run`.
+
+---
+
+## 3. Installation: ein Befehl pro Plattform (Anforderung A + D)
+
+Da Nix das Substrat ist, wird **SOT selbst zu einem Nix-Flake-Paket** — `install.sh` installiert Nix und `nix profile install` das CLI (Prebuilt aus dem **Binary-Cache**, kein Compile). Self-Update = `nix profile upgrade`.
+
+```bash
+# Linux / macOS
+curl -fsSL https://<host>/cli/install.sh | bash
+# Ohne Installation ausprobieren (überall wo Nix ist)
+nix run github:NiklasJavier/SOT -- app list
+# Windows (PowerShell, elevated) → WSL2 + NixOS-WSL + sot-Shim
+irm https://<host>/cli/install.ps1 | iex
+```
+
+**`install.sh`** (Linux/macOS/WSL — einzige verbleibende Shell):
+```bash
+set -euo pipefail
+FLAKE="github:NiklasJavier/SOT"; CACHE_URL="https://<cache>"; CACHE_KEY="<cache>:BASE64KEY="
+command -v nix >/dev/null || {                       # 1. Nix via Determinate-Installer (Multi-User-Daemon, Flakes an)
+  curl -fsSL https://install.determinate.systems/nix | sh -s -- install --no-confirm
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh; }
+mkdir -p "$HOME/.config/nix"                          # 2. Binary-Cache eintragen
+grep -q "$CACHE_URL" "$HOME/.config/nix/nix.conf" 2>/dev/null || cat >>"$HOME/.config/nix/nix.conf" <<EOF
+experimental-features = nix-command flakes
+extra-substituters = $CACHE_URL
+extra-trusted-public-keys = $CACHE_KEY
+EOF
+nix profile install "$FLAKE" --accept-flake-config   # 3. SOT aus Flake+Cache (Download-only)
+echo "sot installiert. Nächster Schritt: sot bootstrap"
+```
+
+- **Debian-spezifisch:** installiert Nix + `sot` — **kein** apt. Laufzeit-Tools kommen später **über Nix** (`sot bootstrap`). Setzt nur `curl`/`ca-certificates` voraus.
+- **Self-Update:** `sot self-update` → `nix profile upgrade sot` (atomar, `nix profile rollback` möglich; kein re-exec/ATOMIC_MOVE mehr).
+- **Kein-Cache-Fallback:** ohne erreichbaren Cache würde Nix aus Quelle bauen (langsam) → Cache ist Pflicht (Risiko 1, §11).
+
+Windows-Details (install.ps1, Shim, NixOS-WSL) → §5.3.
+
+---
+
+## 4. Nix als Substrat (Anforderung C)
+
+Ein neues Package **`de.jklein.sot.nix`**. **`NixService`** ist das **einzige** Gateway zu `nix` (über den geteilten `ProcessRunner`, nie `Runtime.exec`):
 ```java
-public interface InstallStrategy {
-  AppSourceType type();                                      // GIT_REPO | DOCKER_COMPOSE | GITHUB_RELEASE_BINARY | APT_DEB | SCRIPT
-  ResolvedSource resolve(AppManifest m, InstallContext ctx); // bindet+validiert source.options (raw JsonNode → typisierte Slice)
-  InstallOutcome install(ResolvedSource s, InstallContext ctx);
-  InstallOutcome update (ResolvedSource s, InstalledApp cur, InstallContext ctx);
-  void           remove (InstalledApp cur, InstallContext ctx);
+interface NixService {
+  NixEnvironment probe();                 // present, version, flakesEnabled, daemonMode, insideNixOS, system, substituters
+  void ensureExperimentalFeatures();      // persistiert 'nix-command flakes'
+  NixResult profileInstall(NixProfileRef p, FlakeRef ref);  NixResult profileUpgrade(NixProfileRef p, String nameOrAll);
+  NixResult profileRemove(NixProfileRef p, String name);    ProfileList profileList(NixProfileRef p);
+  NixResult build(FlakeRef ref);  JsonNode eval(FlakeRef ref, String attr);  FlakeMetadata flakeMetadata(FlakeRef ref);
+  void ensureSubstituter(BinaryCache cache);   // substituter + trusted-public-key idempotent
 }
-// Verdrahtung: @All List<InstallStrategy> → Map<AppSourceType,InstallStrategy> zur BUILD-Zeit (Closed-World)
 ```
 
-`AppService` ist der einzige Lifecycle-Owner: `list/search/info/install(topo-resolve requires.apps)/update/upgradeAll/remove/pin/unpin/outdated`. Er wählt die Strategie aus der `Map<AppSourceType,…>` und persistiert über `InstalledAppStore`.
-
-### 2.4 Update-Überwachung (das „überwacht, ob geupdated werden kann")
-
-Getrennte Achse `de.jklein.sot.app.update`: ein **`VersionResolver`-SPI** je Quelltyp (`UpdateStrategy` = `GITHUB_RELEASE | GIT_TAG | DOCKER_IMAGE | APT | STATIC | SCRIPT`), ebenfalls `@All`-injiziert. `InstallStrategy.update()` **ruft** den passenden `VersionResolver` — kein doppeltes „latest"-Design.
-
-```java
-interface VersionResolver { UpdateStrategy strategy(); ResolvedVersion resolveLatest(VersionQuery q, ResolverContext ctx); }
-record ResolvedVersion(Optional<Version> latest, String rawLatest, Optional<String> digest, Instant at, CacheDisposition cache) {}
-enum UpdateStatus { UP_TO_DATE, UPDATE_AVAILABLE, PINNED, UNKNOWN, NOT_INSTALLED }
-record OutdatedReport(Instant generatedAt, List<AppUpdateReport> apps, int upToDate, int updatable, int pinned, int unknown) {}
-```
-
-- **`UpdateMonitorService.checkAll()`** fächert `resolveLatest()` über **Virtual Threads** (StructuredTaskScope + Semaphore) über **alle installierten Apps**, vergleicht eine **hand-gerollte, native-sichere `SemVer`** gegen die installierte Version unter Berücksichtigung von `constraint` + Pin, und faltet in einen `OutdatedReport`. Fehler je App → `UNKNOWN`, nie Abbruch.
-- **Kein Daemon.** Das Binary ist kurzlebig (schneller Start ist der Punkt). `sot bootstrap` installiert einen **systemd-Timer** (Cron-Fallback), der `sot app check --quiet --notify` tickt; der Tick schreibt `last-check.json`, `UpdateNotifier` meldet nur bei **Zustandsänderung**. `sot app status`/`outdated` lesen den Cache für sofortige Offline-Anzeige (Netz nur bei `--refresh`).
-- **Robust gegen die Realität:** ETag-Conditional-GETs + TTL-Cache + Serve-Stale bei Rate-Limit; nicht-semver-Tags (calver/sha/`:latest`) werden per **Gleichheit/Digest** verglichen (keine erfundene Ordnung); Pins (`installed.yml`, nicht Manifest): EXACT→eingefroren, RANGE→Update nur innerhalb der Range.
-
-### 2.5 Der App-Selektor (die Bedien-Oberfläche)
-
-Ein Picocli-Parent `sot app` (Aliase `apps`, `a`) — **die eine Vokabel** für das, was früher extensions/plugins/capabilities war. Bare auf einem TTY startet der interaktive Selektor; bare in einer Pipe druckt `list` (blockiert nie).
-
-```
-sot app                      # TTY → interaktiver Selektor · Pipe → list
-sot app browse | select      # Selektor explizit (für Skripte/Tests)
-sot app list [--json] [--outdated] [--role runner]      (alias ls)
-sot app search <query>       # fuzzy über alle Kataloge
-sot app info <id> [--json]   # Manifest, Quelle, installiert/verfügbar, Dep-Baum
-sot app install <id>[@version]… [--yes] [--dry-run]     (alias add, i)
-sot app update <id> | --all [--yes]                     (alias up)   # überspringt Pins
-sot app outdated [--json] [--cached]                    (alias stale) # ← Monitoring-Fläche
-sot app status [<id>]        # Dashboard: up-to-date/outdated/pinned/unknown/broken
-sot app check [--quiet] [--notify] [--refresh]          # Timer-/Refresh-Einstieg
-sot app remove <id> [--yes]                             (alias rm, uninstall)
-sot app pin <id>[@version|range] | sot app unpin <id>
-sot app catalog list | add <url> | remove <id> | refresh   (alias: sot app refresh)
-sot ex …                     # lebendiger Alias: Filter role=runner (AAT/TID-Muscle-Memory)
-sot extensions… | sot plugins…   # deprecated Forwarder → app list/install (mit Hinweis)
-```
-
-Der `AppSelector` ist bewusst **zeilenorientiert** (nummerierte Tabelle via `ConsoleService` + `BufferedReader`-Loop: Zahlen togglen, `/query` fuzzy, `a` alle, `i` install, `u` update, Enter bestätigen, `q` quit). **Kein JLine/ncurses/`stty`** → trivial GraalVM-native-sicher; bei `System.console()==null` verweigert er und fällt auf `list`. Globale Automations-Flags (`--json`, `--yes`, `--no-color`, `--catalog`, `--dry-run`) via `scope=INHERIT`.
+**Reproduzierbare Toolchain (ersetzt `DependencyInstaller`/apt):**
+- **`ToolchainManager`** rendert (Qute) eine SOT-eigene Flake `$SOT_HOME/toolchain/flake.nix` mit `packages.<system>.toolchain = pkgs.buildEnv [ … ]`, **pinned nixpkgs-Input + committed `flake.lock`** = volle Reproduzierbarkeit, installiert als **eine atomare Generation** in ein **dediziertes** Profil `$SOT_HOME/state/profile` (nie das User-Default-Profil).
+- **`NixToolchainReconciler`** (von bootstrap **und** doctor genutzt): Soll-Menge = Kern-Tools ∪ ⋃(`requires.tools` aller installierten Apps) → `NixPackageCatalog` (toolId→nixpkgs-Attr + `NixPkgKind`) → Flake neu rendern → `profileUpgrade`. Voll laufzeit-dynamisch, ohne Java-Rebuild.
+- **`NixInstaller.ensure()`** = idempotenter Determinate-Installer-Fallback (Multi-User-Daemon), **übersprungen wenn `insideNixOS`** (NixOS-WSL bringt Nix mit).
+- **docker-Daemon:** docker-**CLI** = `PROFILE_PKG` (via Nix); **Daemon** = `SYSTEM_SERVICE` → `doctor` delegiert plattformabhängig (NixOS-WSL `virtualisation.docker.enable`, macOS colima/Docker Desktop). Nie einen Daemon ins Profil installieren.
+- **`NixDoctorCheck`:** meldet nix present, Flakes an, Cache erreichbar, jedes Tool auf PATH, docker-Socket.
+- **Standard-Tool-Mapping:** `git→git`, `ansible→ansible`, `terraform→opentofu` *(Default opentofu, vermeidet BSL/unfree; via `SotConfig.tools` überschreibbar)*, `jq→jq`, `cosign→cosign`, `age→age`, `sops→sops`, `docker-cli→docker-client`, `docker→SYSTEM_SERVICE`.
 
 ---
 
-## 3. Installation: der eine Befehl (Anforderung A)
+## 5. Cross-Platform-Delivery (Anforderung D)
 
-Zwei Ebenen — **Ebene 1** ist der geforderte Ein-Zeiler, **Ebene 2** hält aktuell:
+### 5.1 SOT als Nix-Flake
+`flake.nix` im Repo-Root, 4 Systeme (`x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin`). **`packages.<system>.default`** = **`fetchurl`-Wrapper** um das CI-gebaute native Binary (SHA-256-gepinnt), `autoPatchelfHook` (Linux, minimal `buildInputs = [stdenv.cc.cc.lib zlib]`) bzw. `install -Dm755` (darwin). `apps.default` (`nix run`), `devShells.default` (jdk21+gradle+just+mandrel). `nixConfig.extra-substituters` deklariert den Cache → `--accept-flake-config` konfiguriert selbst.
 
-```bash
-# System-weit (→ /usr/local/bin/sot)
-curl -fsSL https://raw.githubusercontent.com/NiklasJavier/SOT/<ref>/install.sh | sudo bash
-# Per-User (→ ~/.local/bin/sot)
-curl -fsSL https://raw.githubusercontent.com/NiklasJavier/SOT/<ref>/install.sh | bash
-# Version pinnen (umgeht die GitHub-API, deterministisch)
-SOT_VERSION=v1.2.0 curl -fsSL …/install.sh | bash
+> **Build-Entscheidung:** **fetchurl-Wrapper statt gradle2nix** für v1 — ein hermetischer GraalVM-Native-Build in der Nix-Sandbox ist schwer/brüchig über 4 Systeme und bringt **keinen** UX-Gewinn (der Cache liefert ohnehin Prebuilt). Das CI-Binary ist die getestete Wahrheit; gradle2nix bleibt als späterer `packages.sot-src`-Track.
+
+### 5.2 Binary-Cache
 ```
-
-**`install.sh`** (die **einzige** verbleibende Shell, `set -euo pipefail`, shellcheck-gegated):
-
-```bash
-REPO=NiklasJavier/SOT
-os=$(uname -s | tr A-Z a-z)                          # linux|darwin
-arch=$(uname -m); case $arch in x86_64) arch=amd64;; aarch64|arm64) arch=arm64;; esac
-tag=${SOT_VERSION:-$(curl -fsSL https://api.github.com/repos/$REPO/releases/latest | grep -m1 tag_name | cut -d'"' -f4)}
-base=https://github.com/$REPO/releases/download/$tag ; asset=sot-$os-$arch
-curl -fsSL -o "$tmp/$asset" "$base/$asset" ; curl -fsSL -o "$tmp/$asset.sha256" "$base/$asset.sha256"
-( cd "$tmp" && sha256sum -c "$asset.sha256" )        # Pflicht
-command -v cosign >/dev/null && cosign verify-blob --certificate "$asset.pem" --signature "$asset.sig" \
-  --certificate-identity-regexp 'https://github.com/NiklasJavier/SOT/.+' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com "$tmp/$asset"   # best-effort
-if [ -w /usr/local/bin ] || command -v sudo >/dev/null; then dest=/usr/local/bin; else dest=$HOME/.local/bin; mkdir -p "$dest"; fi
-${SUDO} install -m755 "$tmp/$asset" "$dest/sot"      # dann: Hinweis „sot bootstrap" / PATH
+# nix.conf (von install.sh/bootstrap geschrieben)
+experimental-features = nix-command flakes
+extra-substituters = https://<cache>
+extra-trusted-public-keys = <cache>:BASE64KEY=
 ```
+CI (`release.yml`): native je System bauen → JReleaser publiziert Assets → SHA-256 → `flake.nix`-Hashes aktualisieren → `nix build .#default` je Runner → **Cache-Push** signierter Store-Paths. `nix profile install` lädt dann Prebuilt.
 
-- **Debian-spezifisch:** installiert **nur** das `sot`-Binary (setzt `curl`/`ca-certificates` voraus). Laufzeit-Tools (git/ansible/docker) werden **nicht** still per apt gezogen — `sot doctor`/`sot bootstrap` erkennen/melden sie (D19).
-- **Fallbacks:** `/usr/local/bin` nicht schreibbar → `~/.local/bin` + PATH-Hinweis; darwin → „build-from-source/JVM"-Meldung statt 404 (v1 shippt linux amd64/arm64).
-- **Ebene 2 — `sot self-update`:** in-Binary, nutzt denselben Asset-/Verify-Kontrakt (GitHub-Release → SHA-256 + cosign → Sibling-Temp → `ATOMIC_MOVE` → re-exec).
-- **Asset-Namens-Kontrakt** (single-sourced zwischen JReleaser und `install.sh`): `sot-<os>-<arch>` + `.sha256` + `.sig` + `.pem`, plus `checksums_sha256.txt`, `sbom.syft.json`.
+### 5.3 Windows via WSL2 (NixOS-WSL)
+Windows = dünner Bootstrapper + Shim; **alle** echte Logik läuft in **NixOS-WSL** (dort ist Nix nativ, `install.sh` läuft unverändert). Kein Windows-natives GraalVM-Target.
+
+- **`install.ps1`** (reboot-resumable State-Machine via `$env:SOT_RESUME`, `HKCU\…\RunOnce`): **0** Preflight (Build ≥19041, Self-Elevate, Virtualisierung) → **A** WSL2 (`wsl --install --no-distribution`, Reboot) → **B** NixOS-WSL installieren (Tarball `nixos.wsl` von `/cli/` laden + `.sha256` prüfen; `wsl --install --from-file` ab 2.4.4, sonst `wsl --import NixOS <dir> nixos.wsl --version 2`) → **C** `wsl -d NixOS -u root -- bash -lc "curl … /cli/install.sh | bash"` → **D** Shim nach `%LOCALAPPDATA%\Programs\sot\bin`, PATH.
+- **Windows-Shim** (`sot.exe`, Rust/Go, code-signiert; `sot.cmd` als Fallback) leitet argv/stdio/Exit-Code an `wsl.exe -d NixOS -e sot …` weiter (ConPTY unter Windows Terminal):
+```rust
+fn main() { let a: Vec<String> = std::env::args().skip(1).collect();
+  let s = std::process::Command::new("wsl.exe").args(["-d","NixOS","-e","sot"]).args(&a).status().unwrap();
+  std::process::exit(s.code().unwrap_or(1)); }
+```
+- **NixOS-WSL-Tarball** bringt `wsl.enable`, `systemd.enable`, `virtualisation.docker.enable`, Cache-Substituter mit (docker läuft **in** WSL, kein Docker Desktop).
+- **Java-Berührungspunkte:** nur `runtime.WslEnvironment` (WSL-Erkennung → doctor/notifier/`SotPaths` adaptieren) + `bootstrap.windows.WindowsShimWriter` (CI-Zeit).
+
+### 5.4 Was dein Host unter `https://<host>/cli/` ausliefert
+`install.sh` · `install.ps1` · `nixos.wsl` (+`.sha256`) · `sot.exe` · `sot.cmd` · `manifest.json` `{sotVersion, wslMinVersion, distroName, tarballSha256}`. Die Binaries selbst kommen aus dem Nix-Cache (bzw. GitHub Releases als Flake-`fetchurl`-Quelle).
+
+### 5.5 macOS
+First-class nativ (Nix auf macOS reif). Secrets ohne tmpfs: `TransientPasswordFile` fällt auf `mkstemp` 0600 unter verschlüsseltem APFS-`$TMPDIR` zurück (`PosixGuards`). Damit ist die frühere „macOS nur JVM/Dev"-Einschränkung **aufgehoben**.
 
 ---
 
-## 4. Ziel-Stack
+## 6. Ziel-Stack
 
-| Ebene | Wahl | Warum |
-|---|---|---|
-| Sprache | **Java 21** (LTS) | Records, sealed types, **virtual threads** (Update-Fan-out), Pattern Matching |
-| Framework | **Quarkus 3.37+** | Für GraalVM native gebaut; Build-Time-DI (Arc) → passt zur Closed-World |
-| CLI | **quarkus-picocli** | Command-Baum, CDI-Injektion, `AutoComplete.GenerateCompletion` (bash/zsh aus dem Spec) |
-| Config/Manifest | **quarkus-jackson + jackson-dataformat-yaml** | Ein Parser; typisierte Records; `#`/Quote/Backslash-Korruption unmöglich |
-| Validierung | **quarkus-hibernate-validator** | Bean-Validation auf Config-/Manifest-Records |
-| Templating | **quarkus-qute** (`@CheckedTemplate`) | Typsicheres Vault-Template, reflection-frei |
-| Native | **Mandrel/GraalVM CE 21** | `-H:+StaticExecutableWithDynamicLibC` (**mostly-static glibc**, nicht musl — s. §7/D1); `resources.includes` bettet Assets ein |
-| **Build** | **Gradle (Groovy DSL)** | *(vom Owner gewählt statt Maven)* Quarkus-Gradle-Plugin; `./gradlew build -Dquarkus.native.enabled=true` |
-| **Dev-Frontend** | **Justfile** (`just`) | *(vom Owner gewählt)* wrappt die Default-Befehle für optimale Ersteinrichtung |
-| Release | **JReleaser (Gradle-Plugin)** + GitHub Actions | Per-Plattform-Binaries, Checksums, SBOM (Syft), cosign auf GitHub Releases |
+Java 21 · Quarkus 3.37+ · quarkus-picocli · quarkus-jackson (+jackson-yaml) · quarkus-hibernate-validator · quarkus-qute · **Gradle (Groovy DSL)** · **Justfile** · **Mandrel native** (`-H:+StaticExecutableWithDynamicLibC`, mostly-static glibc) · **Nix-Flake** + **Binary-Cache** (attic/Cachix) · JReleaser (Gradle-Plugin) · GitHub Actions (native Matrix + Cache-Push).
 
-**Scaffolding & Build (verifiziert gegen aktuelle Quarkus-Docs):**
 ```bash
-quarkus create cli de.jklein.sot:sot --gradle -x picocli          # Gradle-Projekt (Groovy DSL)
+quarkus create cli de.jklein.sot:sot --gradle -x picocli
 ./gradlew addExtension --extensions='quarkus-jackson,quarkus-hibernate-validator,quarkus-qute'
-./gradlew quarkusDev                                              # Live-Reload
-./gradlew build                                                   # JVM-Jar + Tests
-./gradlew build -Dquarkus.native.enabled=true                    # natives Binary
-./gradlew check                                                   # Tests + Int-Tests + JaCoCo (CI-Gate)
-./gradlew jreleaserFullRelease                                   # Release (Binaries/Checksums/SBOM/cosign)
+./gradlew quarkusDev | build | build -Dquarkus.native.enabled=true | check | jreleaserFullRelease
+nix build .#default   # Flake realisiert das (Prebuilt-)Binary
 ```
-
-Native-Flags gehören in `application.properties` (nicht `build.gradle`):
-```properties
-quarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21
-quarkus.native.container-build=true
-quarkus.native.additional-build-args=-H:+StaticExecutableWithDynamicLibC   # mostly-static glibc (fork/exec-sicher), NICHT --libc=musl
-quarkus.native.resources.includes=apps/**,ansible/**,docker/**,templates/**,config/**,assets/manifest.txt
-quarkus.native.add-all-charsets=true
-```
-
-**Justfile** (Entwickler-Entrypoint, wrappt `./gradlew`):
-```
-setup · dev · build · native · test · lint · fmt · run *ARGS · install-local · release TAG · clean
-apps → sot app list · install <id> → sot app install <id> · check → sot app check --refresh · install-timer
-```
+Justfile: `setup·dev·build·native·test·lint·fmt·run·install-local(nix profile install .#default)·release·clean·nix-bootstrap·toolchain-sync·win-build·win-tarball·win-publish`.
 
 ---
 
-## 5. Ziel-Architektur
-
-### Package-Baum (`de.jklein.sot.*`)
+## 7. Ziel-Architektur — Package-Baum
 
 ```
 de.jklein.sot/
-├── cli/         Picocli-Baum: SotCommand(@TopCommand)·Main(@QuarkusMain)·{Bootstrap,Doctor,Vault,Runner,Update,Delete,Interactive}Command
-│               · SotVersionProvider · AliasExpander · ConsoleService/ProgressReporter · SotExitCode
-│   └── app/     App-Selektor-UX: AppCommand(app|apps|a) · AppSelector(zeilenorientiert) · AppTableRenderer · SelectionState
-│               · App{Select,List,Search,Info,Install,Update,Outdated,Status,Remove,Pin,Unpin,Refresh}Command · AppNameCandidates
-│               · ExtensionsCommand/PluginsCommand (deprecated Forwarder)
-├── app/         ★ KERN: AppManifest · SourceSpec · AppSourceType(enum) · InstallStrategy(interface)
-│               · {GitRepo,DockerCompose,GithubReleaseBinary,AptDeb,Script}Strategy · AppCatalog · CatalogSource · CatalogIndex
-│               · InstalledAppStore · InstalledApp · AppService · AppStatus · SemVer · RunnerSpec
-│   └── update/  UpdateMonitorService · VersionResolver(interface) · {GitHubRelease,GitTag,DockerImage,AptPolicy,Script}Resolver
-│               · Version/VersionConstraint · VersionCache · AppUpdateReport/OutdatedReport · UpdateScheduler/UpdateNotifier · InstalledApps(port)
-├── config/      SotConfig + Sektions-Records (System/Ssh/Logging/Paths/Tools/Ansible/Runner/Vault) · CatalogSource-Liste
-│               · YamlConfigCodec · ConfigMerger · PlaceholderResolver · ConfigValidator · SecretStore · ConfigService
-├── vault/       Secret(AutoCloseable) · VaultPasswordSource(sealed) · SecretResolver · TransientPasswordFile · PosixGuards
-│               · AnsibleVaultRunner · SecretGenerator · VaultTemplateRenderer · VaultSecrets · VaultService
-├── process/     ProcessRunner(interface)+Impl · ProcessSpec/Result · ProgressSink/TeeSink · SecretMaterializer
-│               · GitService/GitSyncSpec · GitHubReleaseClient · ChecksumVerifier · WorkspaceManager · ToolPreflight
-├── runner/      AnsiblePlaybookInvocation · AnsibleVaultInvocation · TerraformInvocation · DockerInvocation
-├── bootstrap/   BootstrapTask(interface)+Task-Beans · TaskRunner · TaskResult/BootstrapReport · InstallLayout
-│               · DependencyInstaller · SelfUpdateCommand · BinaryUpdater · BuildInfo
-├── doctor/      DoctorService
-└── runtime/     YamlMapperProducer · SotPaths · AssetExtractor · ReflectionConfig
+├── cli/         SotCommand(@TopCommand)·Main(@QuarkusMain)·{Bootstrap,Doctor,Vault,Runner,SelfUpdate,Delete,Interactive}Command
+│               · ConsoleService/ProgressReporter · SotExitCode
+│   └── app/     AppCommand(app|apps|a)·AppSelector·AppTableRenderer· App{List,Search,Info,Install,Update,Outdated,Status,Remove,Pin,Unpin,Refresh}Command · AppNameCandidates
+├── app/         ★ AppManifest·SourceSpec·AppSourceType{NIX,NIX_FLAKE,GIT_REPO,DOCKER_COMPOSE,SCRIPT}·InstallStrategy
+│               · Nixpkgs/NixFlake/DockerCompose/GitRepo/Script-Strategy · NixProfileManager · AppCatalog·CatalogSource
+│               · InstalledAppStore·InstalledApp·AppService·AppStatus·SemVer·RunnerSpec
+│   └── update/  UpdateMonitorService·VersionResolver·NixVersionResolver·{GitHubRelease,GitTag,DockerImage,Script}Resolver
+│               · Version/VersionConstraint·VersionCache·OutdatedReport·UpdateScheduler/UpdateNotifier
+├── nix/         ★ NixService·NixEnvironment·ToolchainManager·ToolchainFlakeRenderer·NixToolchainReconciler
+│               · NixPackageCatalog·NixPkgKind·NixInstaller·NixBootstrapTask·NixDoctorCheck·BinaryCacheConfig
+├── config/      SotConfig + Sektions-Records · CatalogSource-Liste · YamlConfigCodec·ConfigMerger·PlaceholderResolver
+│               · ConfigValidator·SecretStore·ConfigService
+├── vault/       Secret·VaultPasswordSource(sealed)·SecretResolver·TransientPasswordFile(tmpfs|APFS-mkstemp)·PosixGuards
+│               · AnsibleVaultRunner·SecretGenerator·VaultTemplateRenderer·VaultService
+├── process/     ProcessRunner(interface)+Impl·ProcessSpec/Result·ProgressSink/TeeSink·SecretMaterializer
+│               · GitService/GitSyncSpec·WorkspaceManager·ToolPreflight   (NixService nutzt diesen Runner)
+├── runner/      Ansible{Playbook,Vault}Invocation·TerraformInvocation·DockerInvocation
+├── bootstrap/   BootstrapTask+Task-Beans(inkl. NixBootstrapTask)·TaskRunner·BootstrapReport·InstallLayout
+│               · SelfUpdateCommand(→nix profile upgrade)·BuildInfo · windows/WindowsShimWriter
+├── doctor/      DoctorService (+NixDoctorCheck)
+└── runtime/     YamlMapperProducer·SotPaths·AssetExtractor·ReflectionConfig·WslEnvironment
 
-src/main/resources/   application.properties · config/default_config.yml · templates/vault/secrets.yml (Qute)
-                      · apps/**/app.yml (gebündelte Default-Apps) · ansible/** · docker/** · assets/manifest.txt (build-generiert)
-repo-root/            build.gradle · settings.gradle · gradle.properties · gradlew · Justfile · install.sh
-                      · jreleaser (Gradle-Plugin) · .pre-commit-config.yaml · .github/workflows/{ci,native-build,release}.yml
+src/main/resources/  application.properties·config/default_config.yml·templates/vault/secrets.yml·apps/**/app.yml·assets/manifest.txt
+repo-root/           flake.nix·build.gradle·settings.gradle·gradle.properties·gradlew·Justfile
+                     · install.sh·dist/windows/{install.ps1,sot.exe,sot.cmd,nixos.wsl}·jreleaser·.github/workflows/{ci,native-build,release}.yml
 ```
-
-### Schichten-Diagramm
-
-```mermaid
-graph TD
-    IN["curl … install.sh | bash → natives sot-Binary"] --> CLI
-    subgraph CLI["cli/ + cli/app/ — Picocli + App-Selektor"]
-      ROOT["SotCommand @TopCommand"] --> APPC["AppCommand (Selektor/list/install/update/outdated)"]
-    end
-    APPC --> AS["app/ AppService (Lifecycle-Owner)"]
-    AS --> CAT["AppCatalog (git/http/bundled — Laufzeit-Daten)"]
-    AS --> STR["InstallStrategy ×5 (einkompiliert)"]
-    AS --> UPD["app.update/ UpdateMonitorService"]
-    UPD --> VR["VersionResolver ×5"]
-    STR --> PROC["process/ ProcessRunner · GitService · GitHubReleaseClient"]
-    VR --> PROC
-    ROOT --> OTHER["config/ · vault/ · bootstrap/ · doctor/"]
-    PROC --> EXT["ansible · git · docker · apt · terraform (externe Prozesse)"]
-    AS --> RT["runtime/ SotPaths · YamlMapper · AssetExtractor · ReflectionConfig"]
-    CAT -.Manifeste.-> CATREPO["Katalog-Repo (app.yml, index.yml) — extern, dynamisch"]
-```
-
-### Sieben Prinzipien
-1. **Zwei Achsen getrennt:** Kataloge (Daten, dynamisch) vs. Strategien (Beans, einkompiliert) → tief dynamisch trotz Closed-World.
-2. **Ein Dispatch-Pfad** (`CommandLine.execute`), ein Vokabular (`sot app`), tote Aliase nicht kompilierbar.
-3. **State per Konstruktor-Injektion**, nie positional argv (R3 aufgelöst).
-4. **Ein YAML-Parser, ein Schema** — Config & Manifeste durch denselben typisierten `YAMLMapper`.
-5. **Secrets sind ein Typ** (`Secret`), nie auf argv/Config/Log.
-6. **Ein Install-Root, ein Binary** — alle Pfade aus `SotPaths`; der ausgeführte CLI ist der installierte.
-7. **Build-Time-Wahrheit** — Command-Baum, Strategien, Resolver, Tasks zur Build-Zeit aufgelöst (`@All`).
 
 ---
 
-## 6. Capability-Mapping: Bash → Java
+## 8. Capability-Mapping (Delta ggü. Bash) — Nix-relevant
 
-**Legende:** **[S]** = löst sich *strukturell* auf · **[C]** = *bewusst zu härten* · **[L]** = *manuell in den Ansible-Assets zu fixen*.
-
-| Bash | Java-Ersatz | Grundursache |
+| Bash | Java/Nix-Ersatz | Grundursache |
 |---|---|---|
-| `bin/sot`-Dispatch, `CLI_METADATA_ARGS` | `cli.Main` + `SotCommand`-Baum + Konstruktor-Injektion | R3, A — [S] |
-| `lib/cli/{registry,aliases,progress}.sh`, `colors.sh` + 6 ANSI-Kopien, `completions/*` | `cli/` (Command-Baum, `ConsoleService`, `AutoComplete.GenerateCompletion`) | A/E/I/R6/R7 — [S] |
-| `lib/core/yaml_parser.sh` + 3 weitere Parser, `default_config{,_v2}.yml` | `YamlConfigCodec` + `YamlMapperProducer` + `SotConfig`-Records | R1/D/G/H — [S] |
-| `lib/plugins/manager.sh` + `lib/extensions/manager.sh` + `commands/extensions.sh` (3 Manager, 4 Begriffe) | **`app/` App-Manager** (`AppService`+`AppCatalog`+`InstallStrategy`) — Extension = App mit `runner:` | R2/B — [S] |
-| `modules/*/module.yml`, `parse_plugin_yaml`, `PLUGIN_DEPENDENCIES` | `AppManifest` + `ManifestParser` + topologische `requires.apps` | B — [S] |
-| `_update_config_value`/`save_plugin_state` (persistiert nie) | `InstalledAppStore` (typisiert, atomar) | B/F — [S] |
-| *(neu — Anforderung B)* Update-Überwachung | **`app.update/` `UpdateMonitorService` + `VersionResolver`-SPI** + systemd-Timer | neue Fähigkeit — [C] |
-| `commands/runner.sh`, `trigger.sh` | `process.ProcessRunner` + `runner.*Invocation` | R3/R6 — [S] |
-| Git-Sync (4×), `update.sh` `reset --hard` | `GitService.gitSync(PULL/RESET_HARD, --force-gated)` | R6/G — [S]; Datenverlust — [C] |
-| `commands/vault.sh`, Vault-Rollen, `vault_template.j2` | `vault.VaultService` + `Secret` + `TransientPasswordFile` + Qute | R5/H — [S]; tmpfs/Race — [C] |
-| `bootstrap/init.sh` curl\|bash Selbst-Clone | **`install.sh` (dünn) + Prebuilt-Binary** + `InstallLayout` | R4/C, A — [S]; Root-Wahl — [C] |
-| `bootstrap/{tasks,runner,args_parser,dependencies}.sh` | `BootstrapTask`-Beans + `TaskRunner` + `DependencyInstaller` | F — [S] |
-| `commands/maintenance/{update,delete}.sh` | `SelfUpdateCommand`/`BinaryUpdater` + `SafeFsRemover` | G/H — [S]; Cross-Device/TLS — [C] |
-| **`modules/ansible/roles/*` INHALT** (UFW `allow`, Rollenname, hosts-Regex, Vault-Lifecycle, OS) | **portierte, gefixte Ansible-Assets** (bleiben YAML) | **Thema L (10) — manuell [L]** ⚠️ |
-| `tests/*.sh` + Mock-vault | `@QuarkusTest`/`@QuarkusMainTest`/native-IT + `RecordingProcessRunner` | K — [S] |
-| `.github/workflows/*`, `.pre-commit` | `ci/native-build/release`.yml (Gradle) + JReleaser | R7/I — [S]; native musl/exec — [C] |
+| `bootstrap/dependencies.sh`, `DependencyInstaller` (sdkman/docker/ansible via apt/curl) | **`nix.NixToolchainReconciler` + Toolchain-Flake** (nixpkgs pinned) | Anforderung C — apt entfällt [S] |
+| App-Source `apt-deb` | **`NIX`/`NIX_FLAKE`-Strategien** | 100 % Nix [S] |
+| `bootstrap/init.sh` curl\|bash Selbst-Clone | **`install.sh`: Nix + `nix profile install`** | R4/C, A/C — [S] |
+| `commands/maintenance/update.sh` (`git reset --hard`) | `SelfUpdateCommand` → **`nix profile upgrade sot`** (atomar, rollback) | G — [S] |
+| — (neu) Windows | **`install.ps1` + NixOS-WSL + `sot.exe`-Shim** | D — neue Fähigkeit [C] |
+| **`modules/ansible/roles/*`** (UFW `allow`, Rollenname, hosts-Regex, …) | portierte, **gefixte** Ansible-Assets (bleiben YAML, via Nix-`ansible` ausgeführt) | Thema L (10) — **manuell [L]** ⚠️ |
 
-**Bilanz:** Der Großteil der 88 Befunde löst sich **strukturell [S]** auf; ~8–10 brauchen **Härtung [C]** (native Reflection/Ressourcen, Linking, Secrets, Legacy-Migration, Self-Replace, **Supply-Chain der Kataloge**, Update-Fan-out); **10 (Thema L)** sind manuell in den portierten Ansible-Assets zu fixen (Phase 7).
+Der Rest des Mappings (CLI/Config/Vault/Extensions→App-Manager/Tests/CI) wie in den früheren Abschnitten; die 88 Befunde lösen sich mehrheitlich **strukturell [S]** auf, ~8–10 sind zu **härten [C]**, 10 (Thema L) manuell **[L]**.
 
 ---
 
-## 7. Native-Image-Constraints
+## 9. Native-Image / Nix-Constraints
 
 | Bereich | Was zu tun ist |
 |---|---|
-| **Closed-World-Dynamik (Kernmuster)** | Strategie-/Resolver-**Menge** einkompiliert via `@All List<InstallStrategy>`/`@All List<VersionResolver>` → `Map<enum,bean>` zur Build-Zeit; **welche Apps** existieren = reine Laufzeit-Daten (git/http-Manifeste). Kein `Class.forName`, kein Runtime-Classloading. |
-| **Reflection** | `@RegisterForReflection` zentral in `ReflectionConfig` für **alle** Jackson-Records: `AppManifest`, `SourceSpec`, `VersionSpec`, `Requires`, `InstallSpec`, `RunnerSpec`, `CatalogIndex`, `InstalledApp`, **jede Strategie-Option-Slice**, GitHub-/Docker-Registry-DTOs, Report-Records, `AppNameCandidates`, Picocli-Provider. Sonst binden sie **null**. |
-| **Polymorphie** | `SourceSpec` generisch (`AppSourceType` + roher `JsonNode`), per-Strategie-Binding in `resolve()` — **kein** Jackson `@JsonSubTypes` (bläht die Reflection-Fläche). |
-| **Ressourcen** | Gebündelte Apps unter `src/main/resources/apps/**/app.yml`; `resources.includes` + `AssetExtractor` iteriert das **build-generierte** `assets/manifest.txt` (native kann Classpath nicht `Files.walk`en). |
-| **TLS** | `quarkus.ssl.native=true` + eingebetteter CA-Truststore (api.github.com, ghcr.io, registry-1.docker.io, Debian-Mirror) — geteilt mit Self-Update. |
-| **Prozess-Exec + Linking ⚠️** | **musl-static kann nicht fork/exec** — und jede Install/Update/Version-Prüfung ruft externe Tools. Daher **mostly-static glibc** (`-H:+StaticExecutableWithDynamicLibC`). CI muss echten Subprozess-Aufruf aus dem Binary beweisen. |
-| **Kein Daemon** | Scheduling via externe systemd/cron-Unit (von bootstrap materialisiert); Binary läuft je Tick einmal. |
-| **Kein JLine/ncurses** | Selektor = ANSI-Writes + Zeilen-Reads; `System.console()==null` → verweigern. `Clock` injizieren (deterministisch). |
+| **Binary muss `nix` exec-en ⚠️** | Jeder `NixService`-Call ruft `nix`. Zusammen mit dem App-Manager, der git/docker ruft → **mostly-static glibc** (nicht musl; D1). `autoPatchelfHook` minimal halten (`cc.cc.lib`+`zlib`), sonst mis-patch. CI muss beweisen, dass das **Store-Binary** `nix --version`/`git --version` startet — vor jedem Cache-Push. |
+| **Closed-World-Dynamik** | Strategie-/Resolver-Menge einkompiliert (`@All`→`Map<enum,bean>`); welche Apps/Tools = Laufzeit-Daten (Manifeste, nixpkgs-Attr, Flake-Refs). |
+| **Reflection** | `@RegisterForReflection` zentral: alle Manifest-/Config-/`NixSourceSpec`/`NixEnvironment`/Report-Records + Nix-JSON-DTOs. |
+| **Cache** | Pflicht-Substituter+Key **vor** erster Installation (sonst Compile-from-Source). CI pusht CLI + Toolchain + Katalog-Flakes + pinned nixpkgs-Closure. |
+| **Ressourcen/TLS/Charsets** | `resources.includes` (apps/ansible/docker/templates); `quarkus.ssl.native=true` + CA (github/ghcr/dockerhub); `add-all-charsets=true`. |
 
 ---
 
-## 8. Offene Entscheidungen
-
-Der Multi-Agenten-Entwurf hat Widersprüche zwischen Schichten aufgedeckt; hier **aufgelöst** (⚠️ = load-bearing, bitte bestätigen).
+## 10. Offene Entscheidungen (aufgelöst; ⚠️ = bitte bestätigen)
 
 | # | Entscheidung | Festlegung |
 |---|---|---|
-| **D1** ⚠️ | Native-Linking | **mostly-static glibc** — Korrektheits-Constraint (fork/exec); CI beweist Subprozess-Exec vor Release |
-| **D2** | Root-Package | `de.jklein.sot` |
-| **D3** ⚠️ | Install-Root + Symlink | Root **`/opt/sot`**, Symlink `/usr/local/bin/sot`; `SotPaths`/`InstallLayout` zu **einem** Modell mergen — **bitte bestätigen** |
-| **D4** | Extension/Plugin-Schicht | **Kollabiert in den App-Manager** — Extension = App mit `runner:`; alte Namen nur als Aliase |
-| **D5** | „latest version" — zwei Designs | **`InstallStrategy` (install/update/remove) delegiert an `VersionResolver` (latest)** — orthogonale Achsen (`source.type` ≠ `version.strategy`), kein Doppel-Design |
-| **D6** | Strategie-Vokabular | `AppSourceType{GIT_REPO,DOCKER_COMPOSE,GITHUB_RELEASE_BINARY,APT_DEB,SCRIPT}` (install) ⟂ `UpdateStrategy{GITHUB_RELEASE,GIT_TAG,DOCKER_IMAGE,APT,STATIC,SCRIPT}` (version) |
-| **D7** | `AppService`-Kontrakt | **Ein** Interface (Domänen-Form + Read-Views `catalog()/installed()/outdated()`) |
-| **D8** | Katalog-Refresh-Name | Kanonisch `sot app catalog refresh` (`sot app refresh`/`sync` als Alias) |
-| **D9** | Semver | Hand-gerollt native-sicher (`Version`/`VersionConstraint`); `org.semver4j` als Fallback |
-| **D10** | Scheduling | systemd-Timer (Cron-Fallback) → `sot app check --quiet --notify`; kein In-Process-Daemon |
-| **D11** ⚠️ | **Katalog-Trust (Supply-Chain)** | `CatalogSource.trust` (gepinnter git-ref / cosign+sha256 für http-index); **`script`-Strategie erfordert interaktive Bestätigung**, außer signiert+trusted; dein eigener Katalog ist die einzige Default-Trusted-Quelle — **bitte bestätigen** |
-| **D12** | Rate-Limits/Auth | ETag-Conditional-GETs + TTL-Cache + Serve-Stale; optionaler PAT; Docker-Bearer-Flow |
-| **D13** | Selektor-UI | Zeilenorientiert (kein JLine) |
-| **D14** | Build-DSL | Groovy (Quarkus-Default) |
-| **D15** | JReleaser | Gradle-Plugin (`jreleaserFullRelease`) |
-| **D16** | `install.sh` apt-installs? | **Nein** — nur das `sot`-Binary; Tools via `doctor`/`bootstrap` |
-| **D17** | Version-Pin im Ein-Zeiler | Default `releases/latest`; `SOT_VERSION`/Positional pinnt |
-| **D18** | cosign | Keyless (Fulcio/Rekor, GitHub-OIDC); sha256 Pflicht, cosign best-effort |
-| **D19** ⚠️ | macOS-Scope | v1 **Linux nativ** (amd64/arm64); macOS nur JVM/Dev — **bitte bestätigen** |
-| **D20** | Legacy-Migration | Einmal-Reader (`FAIL_ON_UNKNOWN=false` + Key-Mapping); `module.yml`→`app.yml` (Docker-Templates in je eigene compose-Apps) — nötig nur bei **Feld-Installationen** — **bitte bestätigen** |
+| D1 ⚠️ | Native-Linking | **mostly-static glibc** — muss `nix`/git/docker fork/exec-en (musl kann das nicht). CI beweist Exec. |
+| D2 | Root-Package | `de.jklein.sot` |
+| D3 ⚠️ | Install-Root / Nix-Profile | Programm via `nix profile`; SOT-State unter **`$SOT_HOME` = `/opt/sot`** bzw. `$XDG_STATE_HOME`; dediziertes Toolchain-Profil, nie User-Default — **bestätigen** |
+| D4 | Extension/Plugin → App | kollabiert in App-Manager; AAT/TID = Apps mit `runner:` |
+| D5 ⚠️ | **Binary-Cache: attic (self-hosted) vs Cachix** | **Empfehlung: self-hosted attic auf deiner Domain** (`cache.<domain>`) — passt zu „eigener Host"/100 %-Souveränität; **Cachix** als zero-ops-Schnellstart. **Deine Wahl.** |
+| D6 | CLI-Distribution / Self-Update | SOT = Nix-Flake; Install `nix profile install`, Update `nix profile upgrade sot`; **fetchurl-Wrapper** (nicht gradle2nix) für v1 |
+| D7 | Nix-Modus | Multi-User-Daemon (Determinate); übersprungen in NixOS-WSL |
+| D8 | Tool-Profil-Modell | **eine buildEnv-Toolchain** (pinned nixpkgs + `flake.lock`) im dedizierten Profil; `NixToolProvisioner` routet dadurch |
+| D9 | App-Profile | pro-App-Profile (Rollback/Isolation); `nix profile install` default, `mode: build` opt-in |
+| D10 | terraform | **opentofu** als Default (BSL/unfree vermeiden), via `SotConfig.tools` überschreibbar |
+| D11 | AppSourceType/UpdateStrategy | wie §2 (NIX/NIX_FLAKE rein, APT_DEB/APT + GITHUB_RELEASE_BINARY-App-Source raus) |
+| D12 ⚠️ | Windows-Linux-Env | **NixOS-WSL** (100 % Nix); `sot.exe`-Shim primär, `sot.cmd`-Fallback — **bestätigen** |
+| D13 | macOS | first-class nativ; Secrets via APFS-`mkstemp` 0600 |
+| D14 | Determinate-Installer-Trust | Version pinnen + Checksum in `install.sh`; https-only |
+| D15 ⚠️ | Legacy-Migration | `apt-deb`→`nix`-Migrations-Reader + alte `/usr/local/bin/sot`-Erkennung — nötig nur bei **Feld-Installationen** — **bestätigen** |
 
 ---
 
-## 9. Migrations-Phasen (Greenfield, „Strangler" bis Parität)
+## 11. Migrations-Phasen (Greenfield, „Strangler")
 
-Neubau in einem Gradle-Modul, Fähigkeit für Fähigkeit, jede Phase eine PR mit **Abnahme-Gate**. Aufwand: **S** ≤ 2 T, **M** ≈ 3–5 T, **L** ≈ 1–2 Wo.
+- **P0 — Skelett & Foundation** *(L, D1–D2)* — Gradle/Quarkus/Java-21, Justfile, `sot version` nativ, `runtime.*`, CI-JVM-Verify + **linux-amd64-Native-Smoke, der einen echten Subprozess startet**. Gate: nativ + exec-fähig.
+- **P1 — Config-Kern** *(L)* — `SotConfig`-Records, ein YAML-Codec, Validierung, `SecretStore`, `CatalogSource`-Liste. Gate: Roundtrip + native-IT.
+- **P2 — Prozess-Engine** *(M)* — `ProcessRunner`, `GitService`, `SecretMaterializer`, `WorkspaceManager`, `ToolPreflight`. Gate: echter `git`-Exec nativ.
+- **P3 — ★ Nix-Substrat** *(L, Anf. C)* — `NixService` + `NixEnvironment`, `ToolchainManager`/`Renderer`/`Reconciler`, `NixPackageCatalog`, `NixInstaller`, `NixBootstrapTask`, `NixDoctorCheck`, Cache-Config. Gate: `sot bootstrap` stellt Toolchain (git/ansible/opentofu) rein über Nix bereit; doctor grün.
+- **P4 — CLI-Gerüst** *(M)* — Command-Baum, Hilfe/Version/Completion, Exit-Codes. Gate: `@QuarkusMainTest`.
+- **P5 — ★ App-Kern (Nix-first)** *(L, Anf. B)* — `AppManifest`/`ManifestParser`, `AppCatalog`, `Nixpkgs`/`NixFlake`/`DockerCompose`/`GitRepo`/`Script`-Strategien, `NixProfileManager`, `AppService`, `InstalledAppStore`. Gate: install/update/remove/persist je Strategie über Test-Katalog + Cache.
+- **P6 — ★ Update-Überwachung** *(L, Anf. B)* — `VersionResolver`-SPI + `NixVersionResolver`, `UpdateMonitorService` (Virtual-Threads), `VersionCache`, Pins, Timer/Notifier. Gate: `outdated` korrekt (up-to-date/outdated/pinned/unknown).
+- **P7 — ★ App-Selektor & Surface** *(M, Anf. B)* — `AppCommand`-Baum, `AppSelector`, `--json/--yes`, Completion, `ex`/deprecated Forwarder. Gate: e2e, non-TTY→list.
+- **P8 — Vault, Bootstrap-Tasks, Runner & Ansible-Assets** *(L, +Thema L)* — `VaultService`/`Secret`/tmpfs|APFS, Task-Pipeline, `RunnerCommand`; **Ansible-Assets fixen** (UFW `deny`, Rollenname, hosts-Regex, Vault-Lifecycle, OS-Abstraktion; via Nix-`ansible`). Gate: `sot bootstrap` gegen Wegwerf-Container; `ansible-lint`; Vault-Roundtrip.
+- **P9 — ★ Cross-Platform-Delivery** *(L, Anf. A+D)* — `flake.nix` (4 Systeme, fetchurl-Wrapper), Binary-Cache (attic/Cachix) + CI-Push, `install.sh` (Nix→profile install), `SelfUpdateCommand`, JReleaser-Multi-Arch, macOS-Runner. Gate: `install.sh` installiert `sot` in **frischem Debian-Container** und **auf macOS**; `nix profile upgrade` funktioniert.
+- **P10 — ★ Windows/WSL2** *(L, Anf. D)* — `install.ps1` (reboot-resumable), NixOS-WSL-Tarball, `sot.exe`/`sot.cmd`-Shim, `WslEnvironment`. Gate: `irm … | iex` in **frischer Windows-VM** → `sot app` läuft über den Shim.
+- **P11 — Parität, Cutover & Legacy** *(M)* — volle Coverage, `apt-deb→nix`/`module.yml→app.yml`/Legacy-Binary-Migration, **88-Befund-Regressions-Checkliste** ([S]/[C]/[L] mit Nachweis), Bash entfernen, README neu. Gate: Checkliste 100 %.
 
-- **Phase 0 — Skelett & Foundation** *(L · fixiert D1–D4)* — Gradle/Quarkus/Java-21, `Justfile`, `quarkus-picocli`-`sot version`, `YamlMapperProducer`/`SotPaths`/`AssetExtractor`/`ReflectionConfig`, `ci.yml` mit **JVM-Verify + linux-amd64-Native-Smoke, der einen echten Subprozess startet** (verifiziert D1). **Gate:** `sot version` nativ + Native-Binary ruft `git --version`.
-- **Phase 1 — Config-Kern** *(L · löst R1/D)* — `SotConfig`-Records, `YamlConfigCodec`, Merge/Placeholder/Validator, `SecretStore`, `CatalogSource`-Liste in der Config. **Gate:** Config-Roundtrip + native-IT bindet `default_config.yml`.
-- **Phase 2 — Prozess-/Exec-Engine** *(M · löst R6)* — `ProcessRunner`+Impl, `GitService`, `GitHubReleaseClient`, `ChecksumVerifier`, `SecretMaterializer`, `WorkspaceManager`, `ToolPreflight`. **Gate:** Native-Smoke ruft echtes `git`.
-- **Phase 3 — CLI-Gerüst** *(M · löst A/F-Dispatch)* — `SotCommand`-Baum, `Main`, Hilfe/Version/Completion, Aliase, Exit-Codes, `ConsoleService`. **Gate:** `@QuarkusMainTest` e2e.
-- **Phase 4 — ★ App-Manager Kern** *(L · Anforderung B, löst R2/B)* — `AppManifest`+`ManifestParser`, `AppCatalog` (git/http/bundled), 5 `InstallStrategy`-Beans, `AppService`, `InstalledAppStore`, `SafeFsRemover`, `requires`-Topo-Sort. **Gate:** install/update/remove/**persist** je Strategie über einen Test-Katalog; kaputtes Manifest failt bei Discovery.
-- **Phase 5 — ★ Update-Überwachung** *(L · Anforderung B)* — `VersionResolver`-SPI (5), `UpdateMonitorService` (Virtual-Thread-Fan-out), `VersionCache` (ETag/TTL/Serve-Stale), `SemVer`/`VersionConstraint`, Pins, `UpdateScheduler`/`UpdateNotifier`. **Gate:** `outdated` über Mock-Resolver korrekt (up-to-date/outdated/pinned/unknown); Cache-Roundtrip.
-- **Phase 6 — ★ App-Selektor & Command-Surface** *(M · Anforderung B)* — `AppCommand`-Baum, `AppSelector` (zeilenorientiert), Renderer, alle Subcommands, `--json`/`--yes`, `AppNameCandidates`-Completion, `ex`/deprecated Forwarder. **Gate:** `@QuarkusMainTest` über list/install/outdated/selector; non-TTY→list.
-- **Phase 7 — Vault, Bootstrap, Runner & Ansible-Assets** *(L · löst R5/C/F + Thema L)* — `VaultService`+`Secret`+tmpfs, `BootstrapTask`-Pipeline, `DependencyInstaller`, `RunnerCommand`, systemd-Timer-Materialisierung; **Ansible-Assets fixen** (UFW `deny`, Rollenname, hosts-Regex, Vault-Lifecycle, OS-Abstraktion). **Gate:** `sot bootstrap` gegen Wegwerf-Container; `ansible-lint`; Vault-Roundtrip.
-- **Phase 8 — Install-Einzeiler, Packaging & Release** *(L · Anforderung A, löst R7)* — `install.sh` (uname/download/verify/PATH), `SelfUpdateCommand`+`BinaryUpdater`, JReleaser-Gradle-Multi-Arch, `native-build.yml`/`release.yml`, `.pre-commit`. **Gate:** Getaggter Release → verifizierte Binaries; **der Ein-Zeiler installiert `sot` in einem frischen Debian-Container**; `sot self-update`-Roundtrip.
-- **Phase 9 — Parität, Cutover & Legacy-Migration** *(M · final)* — volle Coverage, Legacy-`config.yaml`/`module.yml`→`app.yml`-Migrations-Reader, **88-Befund-Regressions-Checkliste** (jedes [S] weg, [C] mitigiert, [L] gefixt), Bash entfernen, README neu. **Gate:** Checkliste 100 %; `mvn`/`pom.xml`/`--libc=musl`-grep leer.
-
-### Sequenz
-```
-0 (Skelett, D1) → 1 (Config) & 2 (Exec)
-                     └→ 3 (CLI) → 4 (App-Kern) → 5 (Update-Monitor) → 6 (Selektor)
-                     └→ 7 (Vault/Bootstrap/Ansible)   [parallel ab 2]
-8 (Install/Release)  [ab 0 vorbereitbar, voll ab lauffähiger App]
-9 (Parität/Cutover)  [zuletzt]
-```
-**Kritischer Pfad:** 0 → 1/2 → 3 → 4 → 5 → 6 → 8 → 9. Der App-Manager (4–6) ist der Wertkern und der größte Brocken.
+**Kritischer Pfad:** P0 → P1/P2 → **P3 (Nix)** → P4 → **P5 → P6 → P7 (App-Manager)** → **P9 (Delivery)** → P10 (Windows) → P11. P8 parallel ab P3.
 
 ---
 
-## 10. Verifikationsstrategie
+## 12. Verifikation & Risiken
 
-- **Drei Test-Tiers:** `@QuarkusTest` (JVM, gemockter `ProcessRunner`/`VersionResolver`) · `@QuarkusMainTest` (CLI-e2e) · `@QuarkusMainIntegrationTest` (**native** Black-Box, `FakeToolPathResource`).
-- **Native-Gate Pflicht:** ein natives IT lädt Config, parst je ein Manifest **jedes** `source.type`, startet einen echten Subprozess (`git --version`) — verwandelt Reflection-/Linking-Fehler in gefangene CI-Fehler.
-- **Release-Smoke:** der publizierte Ein-Zeiler wird in einem **frischen Debian-Container** gegen den echten Release ausgeführt (Anforderung A).
-- **Paritäts-Checkliste** gegen `refactoring-findings.md`: jeder der 88 Befunde bekommt Status [S]/[C]/[L] mit Nachweis — Abnahme für Phase 9.
-- **Supply-Chain-Test:** ein unsigniertes Katalog-Manifest mit `script`-Strategie muss ohne Bestätigung **abgelehnt** werden.
-- **CI failt hart** (kein `|| true`).
+**Verifikation:** 3 Test-Tiers (`@QuarkusTest` mit gemocktem `ProcessRunner`/`NixService` · `@QuarkusMainTest` · nativer `@QuarkusMainIntegrationTest`). **Native-Gate** beweist Nix-/Tool-Exec aus dem Store-Binary. **Release-Smokes:** `install.sh` in frischem Debian- **und** macOS-Runner; `install.ps1` in Windows-VM. **Paritäts-Checkliste** gegen `refactoring-findings.md`. CI failt hart.
 
----
-
-## 11. Risiken & Gegenmaßnahmen (Top 8)
-
-| # | Risiko | Gegenmaßnahme |
-|---|---|---|
-| 1 ⚠️ | **musl-static kann nicht fork/exec** | mostly-static glibc; CI beweist Subprozess-Exec vor Release (D1) |
-| 2 ⚠️ | **Supply-Chain / RCE** — Katalog-Manifest mit `script`/deb-Strategie führt Fremdcode aus; `curl\|bash` ist MITM-Fläche | Kataloge signieren/pinnen (git-ref bzw. cosign+sha256); `script` nur mit Bestätigung außer trusted; `install.sh` sha256 **Pflicht** + cosign keyless, nur https (D11/D18) |
-| 3 | Native-Reflection-Miss → stilles null-Binden → Fehl-Installation | zentrale `ReflectionConfig`; native-IT bindet je `source.type` ein Manifest voll |
-| 4 | `outdated`-Fan-out langsam / rate-limited (60 GitHub-Calls/h unauth) | Virtual-Threads + ETag-Conditional-GETs (304 gratis) + TTL-Cache + Serve-Stale + optionaler PAT + denormalisierte Version im Index |
-| 5 | Versions-Heterogenität (calver/sha/`:latest`) → falsche Ordnung | Gleichheit/Digest statt erfundener Ordnung; optionaler `tagPattern`; sonst `UNKNOWN` |
-| 6 | Selektor blockiert nicht-interaktiv (CI, Pipe) | `System.console()==null`→`list`; jede mutierende Verb-Form hat `--yes` |
-| 7 | `install.sh`-Asset-Namen driften von JReleaser | Schema `sot-<os>-<arch>` single-sourcen; Release-Smoke im Container |
-| 8 | Destruktiver `RESET_HARD` / `rm -rf` | `--force`-Gate; `SafeFsRemover`-Denylist; eine auditierte `GitService`-Methode |
+**Top-Risiken:**
+1. **Cache-Miss → Compile-from-Source** (bricht Erst-Install-UX). → Pflicht-Substituter+Key vor erster Installation; CI pusht **alles** in den Cache; doctor flaggt unerreichbaren Cache; `ProgressReporter`-Warnung.
+2. ⚠️ **Native-Binary kann `nix`/Tools nicht exec-en / `autoPatchelfHook` mis-patch.** → mostly-static glibc; minimale `buildInputs`; CI-Exec-Beweis vor Cache-Push.
+3. **Non-trusted-user ehrt `extra-substituters` nicht → stiller Source-Build.** → Determinate macht Installierer zum trusted-user; `install.sh` verifiziert, bietet System-`/etc/nix/nix.conf`; `--accept-flake-config`.
+4. **Nix absent / Flakes aus.** → `install.sh` Determinate-Installer; `ToolPreflight`/doctor mit einer klaren Remediation.
+5. **Supply-Chain: Determinate `curl|sh` + `nixos.wsl`-Tarball.** → Installer-Version pinnen + Checksum; `nixos.wsl.sha256` + `manifest.json`, hartes Fail bei Mismatch.
+6. **`outdated`-Fan-out langsam / Nicht-SemVer-Nix-Versionen.** → Virtual-Threads + `VersionCache` + denormalisierte Rev; Flakes per Rev-Gleichheit, nixpkgs nur bei parsebarem SemVer, sonst `UNKNOWN`.
+7. **Windows:** WSL2 fehlt/Virtualisierung aus, Reboot-Resume fragil, SmartScreen blockt `sot.exe`. → Preflight ≥19041+Virt; idempotente Stages + RunOnce; `install.ps1`/`sot.exe` code-signen + `sot.cmd`-Fallback.
+8. **Datenverlust/Destruktiv** (`RESET_HARD`, `rm -rf`). → `--force`-Gate; `SafeFsRemover`-Denylist; pro-App-Profil-Remove ist sauber (Generationen).
 
 ---
 
-## 12. Aufwand (Größenordnung)
+## 13. Aufwand
 
-Für **eine erfahrene Person** grob **~12–16 Wochen** (Skelett/Config/Exec/CLI je ~1–2 Wo; **App-Kern + Update-Monitor + Selektor je ~1.5–2 Wo — der Wertkern**; Vault/Bootstrap/Ansible ~1.5 Wo; Install/Release ~1 Wo; Parität/Cutover ~1 Wo). Mit 2–3 Personen ab Phase 1 parallelisierbar (Config/Exec/Vault unabhängig; App-Kern → Update → Selektor seriell) auf **~7–9 Wochen**. Wichtigster Risiko-Hebel: das native-image-Gate **und** einen End-to-End-Dünnschnitt (`sot version` nativ → Install-Einzeiler) **früh** (Phase 0/8-Vorzug) etablieren.
+Für **eine erfahrene Person** grob **~16–20 Wochen** (jetzt inkl. Nix-Substrat P3 ~1.5–2 Wo, Cross-Platform-Delivery P9 ~1.5 Wo, Windows/WSL2 P10 ~1.5–2 Wo zusätzlich zum App-Manager-Kern). Mit 2–3 Personen ab P1 parallelisierbar (Config/Exec/Nix/Vault unabhängig; App-Kern→Update→Selektor seriell; Windows nach Delivery) auf **~9–12 Wochen**. Wichtigster Hebel: **früher End-to-End-Dünnschnitt** — `sot version` nativ → als Flake paketiert → `install.sh` (Nix + `nix profile install`) in einem Debian-Container grün — validiert D1, Cache und den ganzen Delivery-Pfad, bevor der App-Manager gebaut wird.

--- a/docs/refactoring-findings.md
+++ b/docs/refactoring-findings.md
@@ -1,0 +1,277 @@
+# SOT Bash Toolkit — Consolidated Findings
+
+_Synthesis of 10 subsystem-map agents + 5 cross-cutting audit agents. Deduplicated; every distinct file:line defect preserved. The repo is mid-refactor (`setup→bootstrap`, `integrations→extensions`, `flat v1 → nested v2 config`, `cli_wrapper.sh` removed); most defects are drift artifacts of these half-finished renames._
+
+---
+
+## 1. Subsystem Map
+
+**1. CLI entry point / dispatch / registry / aliases / progress** — Turns `sot <cmd> [args]` into a resolved command script and executes it, appending framework metadata. `bin/sot` (set -euo pipefail) bootstraps `SOT_ROOT`, sources `lib/init.sh` + cli/plugins libs, parses config into flat vars, builds a 10-element positional `CLI_METADATA_ARGS`, hand-registers commands, then dispatches via alias-expansion → big `case` → `*`→`resolve_and_execute` (longest-prefix registry match, else filesystem `resolve_command_path`).
+- `bin/sot` — entry: path bootstrap, config load, CLI_METADATA_ARGS, dispatch, execute_script (504 lines)
+- `lib/cli/registry.sh` — registry data model + register_command; UNUSED auto-discovery; help/menu/completion generators (436)
+- `lib/cli/aliases.sh` — CLI_ALIASES map + single-token expansion (192)
+- `lib/cli/progress.sh` — progress bars, spinner, task-list widgets (434)
+- `lib/init.sh` — idempotent library loader (35)
+
+**2. Core reusable library (colors, helpers, YAML parser)** — Shared foundation: ANSI/semantic colors, colored stderr helpers (err/warn/info/success), generic utilities, and a pure-Bash YAML reader handling both flat v1 and nested v2 schemas. `lib/init.sh` sources colors→yaml→helpers (each self-guarded). YAML has three tiers (flat `parse_yaml_to_vars`, nested `parse_nested_yaml`, smart `load_config` that sniffs indentation and flattens); every line cleaned via `echo|cut|xargs|tr`.
+- `lib/core/yaml_parser.sh` — flat + nested parsers, getters, smart load_config (362)
+- `lib/core/helpers.sh` — is_true/ensure_dir/resolve_path/log_command + output helpers (192)
+- `lib/core/colors.sh` — raw ANSI + deprecated aliases + COLOR_* semantic layer (33)
+- `commands/runner.sh` — only production consumer of `load_config` (get_cfg wrapper)
+- `lib/core/bootstrap/config_defaults.sh` — parallel/duplicate YAML reader bypassing yaml_parser.sh
+
+**3. Extensions Manager & Plugin Manager** — Two parallel, unrelated registries for "pluggable" capability. Extensions manager (config-var-driven) git-clones external repos (AAT/TID) via indirect `${name}_${prop}` env vars; auto-sourced by init.sh everywhere. Plugin manager (filesystem-driven) discovers `modules/*/module.yml`, populates 10 `PLUGIN_*` assoc arrays via a bespoke parser, and dispatches installers/commands; sourced only by `bin/sot`. No shared code.
+- `lib/plugins/manager.sh` — plugin registry, bespoke YAML parser, lifecycle, dispatch (584)
+- `lib/extensions/manager.sh` — config-var-driven external-repo manager (235)
+- `commands/extensions.sh` — CLI front-end for extensions manager (395)
+- `modules/ansible/module.yml` — richest manifest; only 8 flat keys consumed (52)
+
+**4. Config defaults / overrides / completions** — Default templates that seed installs, `__GENERATE_*__` placeholder resolution, and bash/zsh completions. Meant to be the single source of truth for settings, but split across two incompatible schemas (flat `default_config.yml` = production; nested `default_config_v2.yml` = tests/docs only), FOUR config readers, and THREE divergent completion definitions.
+- `config/default_config.yml` — v1 FLAT production defaults (still carries dead integrations schema) (82)
+- `config/default_config_v2.yml` — v2 NESTED template; referenced only by tests/docs (113)
+- `completions/sot-completion.{bash,zsh}` — static completions, stale command set, never installed
+- `lib/core/bootstrap/config_writer.sh` — writes runtime config in NESTED v2 format (132)
+
+**5. Bootstrap library (`lib/core/bootstrap/*`)** — Library behind `bootstrap/init.sh`: turns CLI flags + default YAML into resolved config, writes per-branch `config.yaml`, runs ordered setup tasks with a progress UI. All inter-function communication is via mutable UPPERCASE global scalars. Flow: parse_early_args → load_default_config → apply_config_defaults → parse_setup_args → generate_dynamic_defaults → run_tasks.
+- `lib/core/bootstrap/args_parser.sh` — parse_early_args + parse_setup_args flag switch (315)
+- `lib/core/bootstrap/config_defaults.sh` — YAML loader + `__GENERATE_*__` resolution (203)
+- `lib/core/bootstrap/config_writer.sh` — heredoc of globals into config.yaml (132)
+- `lib/core/bootstrap/tasks.sh` — task_* (clone, dirs, CLI edit, symlink, deps) (289)
+- `lib/core/bootstrap/runner.sh` — TASK_LABELS, critical-task list, run_task(s) (236)
+
+**6. modules/ansible** — Self-contained Ansible tree + `trigger.sh` wrapper that `SOT bootstrap` invokes to configure the local host (packages/hostname/SSH/user/firewall + encrypted ansible-vault secrets). `host_setup.yml` runs roles variables→common→protection→vault; `load_config.yml` merges default+override into one `sot_config` fact and derives `__GENERATE_*__` values.
+- `modules/ansible/commands/trigger.sh` — bash wrapper: resolves cfg/inventory, ensures ansible+docker, runs playbook (78)
+- `modules/ansible/config/load_config.yml` — central config merge + generated-value derivation (94)
+- `modules/ansible/roles/vault/tasks/main.yml` — creates/encrypts vault, temp-file shred cleanup (153)
+- `modules/ansible/roles/common/tasks/main.yml` — apt/hostname/hosts/sshd/user/authorized_keys (53)
+- `modules/ansible/roles/protection/tasks/main.yml` — UFW install/enable (22)
+
+**7. User-facing command scripts (`commands/*`)** — Concrete verb implementations (bootstrap, runner, vault, doctor, extensions, maintenance). Each is standalone bash sourcing `lib/init.sh`. Three incompatible arg-handling contracts coexist: positional-metadata (bootstrap/vault/cleanup), explicit split (runner only — correct), and getopts+env (doctor/delete/update/extensions — swallow metadata, read empty env).
+- `commands/runner.sh` — Ansible/Terraform engine; only correct user-vs-metadata arg split (890)
+- `commands/doctor.sh` — health-check/repair (453)
+- `commands/maintenance/delete.sh` — full uninstaller; reads unexported env → hardcoded defaults (397)
+- `commands/maintenance/update.sh` — git fetch + reset --hard of core + extensions (266)
+- `commands/vault.sh` — ansible-vault edit wrapper, RAM-tmpfs secret handling (190)
+
+**8. Remote installer / bootstrap entrypoint / deps / vault templating** — The `curl|bash` (or local `sudo`) entrypoint: clones the repo, generates per-branch `config.yaml`, installs SDKMAN/Docker/Ansible, wires CLI symlinks, and supplies the Jinja2 vault template. `bootstrap/init.sh` detects bootstrap-mode via `BASH_SOURCE`, clones to `/opt/SOT`, re-execs locally; tasks re-clone to `/etc/DevOpsToolkit`. _(Heavy overlap with subsystem 5.)_
+- `bootstrap/init.sh` — entrypoint: curl|bash detection, re-clone/re-exec, SETUP_TASKS (208)
+- `bootstrap/dependencies.sh` — tool-installer dispatcher (sdkman/docker/ansible only) (122)
+- `bootstrap/vault_template.j2` — Jinja2 vault template generating db/api secrets (55)
+- `modules/ansible/roles/vault/tasks/main.yml` — consumes vault_content/secret/file, encrypts
+
+**9. Documentation & Project Meta** — German Markdown docs (README + docs/*), CONTRIBUTING, four GitHub Actions workflows, pre-commit, editorconfig. Only `test.yml` tracks the post-refactor `tests/` layout; every prose doc, `security.yml`, and the completions still describe a repo that no longer exists.
+- `README.md` — primary doc; heavily drifted (ci/, integrations, paths, dead links) (516)
+- `docs/cli-reference.md` — documents removed command surface + wrong injected-param contract (248)
+- `.github/workflows/test.yml` — the ONE meta file updated to tests/ layout — source of truth (106)
+- `.github/workflows/security.yml` — ShellCheck targets nonexistent scripts//ci/ dirs (silent no-op) (179)
+
+**10. Test suite (`tests/` + test.yml)** — Bash harness: master runner + 3 unit + 4 integration suites, hand-rolled assertions, no framework. `run-all.sh` runs a hardcoded 7-suite list in subprocesses; `setup-env.sh` builds runtime `ci/` scratch, a mock `ansible-vault`, and fixture config/vault files. CI runs unit → integration (after real `bootstrap/init.sh`) → full suite.
+- `tests/run-all.sh` — master runner, hardcoded 7-suite list (74)
+- `tests/setup-env.sh` — CI fixture: ci/ scratch, mock ansible-vault, exports env (100)
+- `tests/unit/{helpers,yaml,setup}.sh` — unit suites (helpers/YAML/bootstrap-config)
+- `tests/integration/{cli,config,integration,vault}.sh` — integration suites
+
+---
+
+## 2. Consolidated Problem Inventory
+
+Severity in brackets. Merged entries cite all locations.
+
+### A. Command dispatch & routing
+- **[medium]** Two parallel resolution mechanisms + duplicated arms: `doctor/update/delete/plugins` have explicit `case` arms AND registry entries, while `bootstrap/vault/runner/extensions` rely solely on `*`→`resolve_and_execute` (registry longest-prefix vs filesystem `resolve_command_path`). Behavior depends on which branch a verb hits. `bin/sot:421-500`. → Route everything through one alias-expansion → `resolve_and_execute` table; keep only true meta-flags.
+- **[low]** `integrations)` case arm is unreachable — alias expansion rewrites `integrations`→`extensions` before the case evaluates. `bin/sot:453-456`. → Delete.
+- **[low]** Plugin commands registered with an empty script path, so they only run via the special-cased `plugin_exists` branch, never through `resolve_and_execute` — registry and dispatch are disconnected. `bin/sot`, `lib/plugins/manager.sh`. → Give plugin commands a real executor token.
+- **[low]** `show_categorized_help` hardcodes the alias cheat-sheet (`sot s = sot setup`) as literal printf lines instead of deriving from `CLI_ALIASES`, so it drifts. `lib/cli/registry.sh:180-215`. → Generate from live data.
+
+### B. Plugin / Extension / Integration / Module conceptual overlap
+- **[high]** FOUR overlapping terms for two concepts, backed by THREE disjoint subsystems: `modules/` dirs discovered as "plugins" (`PLUGIN_*`); external git repos (aat/tid) managed as "extensions" via `<name>_enabled` env vars; "integration" still a first-class plugin TYPE + legacy `integrations` command + README wording. A plugin and an extension are the same concept but share no discovery, config format, lifecycle, or CLI path; even entrypoints differ (init.sh sources extensions, bin/sot sources plugins). `lib/plugins/manager.sh:26-40`, `lib/extensions/manager.sh:19-30`, `bin/sot:67,453`, `config/default_config.yml:29-59`. → Collapse to ONE concept with one registry; model a remote git repo as one provider strategy behind the same interface.
+- **[high]** Two managers reimplement the same lifecycle (enabled-check, list, info-render, run-subcommand) against different backends (env-vars vs assoc-arrays); enable/disable exists a THIRD time in `commands/extensions.sh`. `lib/extensions/manager.sh:39-234`, `lib/plugins/manager.sh:218-499`, `commands/extensions.sh:318-340`. → Merge into one manager.
+- **[high]** `module.yml` contract is incoherent: manifests declare rich nested structure (requirements.packages lists, templates list-of-maps, config maps, playbooks/roles, block scalars) but `parse_plugin_yaml` is a naive one-level parser that flattens to `${section}_${key}` and collapses lists. Only ~8 flat keys are consumed; `requirements/config/playbooks/roles/templates/sdks/notes` are declared and silently ignored; `dependencies:` (plugin deps) is conflated with `requirements.packages` (OS packages). `lib/plugins/manager.sh:50-103,154-167`, `modules/*/module.yml`. → Make manifest schema and parser agree (restrict to flat keys or parse with real YAML + versioned schema; validate at discovery).
+- **[medium]** `PLUGIN_DEPENDENCIES` populated and displayed but never enforced — `install_plugin` runs the installer without resolving deps. `lib/plugins/manager.sh:166,493`.
+- **[medium]** Two overlapping type taxonomies: extensions header says `ansible|terraform|script`, plugins use `tool|service|integration`; the plugin `integration` type IS the extensions concept. `lib/plugins/manager.sh:13,31`.
+- **[low]** Extension record rendered three times (manager `extension_info` + `cmd_list` + `show_usage`), each re-querying/re-formatting. `lib/extensions/manager.sh:186-204`, `commands/extensions.sh:79-115,27-73`.
+
+### C. Path & installation drift
+- **[high]** Two contradictory install roots: bootstrap clones to `/opt/SOT` and re-execs there, but `task_clone_repository` clones AGAIN to `CLONE_DIR=/etc/DevOpsToolkit` and derives MODULES_DIR/CLI_FILE from it; `bin/sot` even has an `/opt/AAT` (foreign product) SOT_ROOT fallback. Double-clone, split-brain paths, plugin discovery can look under the wrong root. `bootstrap/init.sh:34`, `bin/sot:19,26-27`, `lib/core/bootstrap/config_defaults.sh:122`, `config/default_config.yml:13`. → One canonical root; derive all paths from `SOT_ROOT`; remove /opt/AAT fallback.
+- **[high]** CLI-edit vs symlink target are different trees: `task_edit_cli` patches `$CLONE_DIR/bin/sot` (/etc/DevOpsToolkit) while `task_create_cli_symlink` points `/usr/sbin/SOT` + `/usr/local/lib/sot` + `/usr/local/bin/sot-bin` at `$SOT_ROOT/bin/sot` (/opt/SOT) — users invoke the un-patched copy. `lib/core/bootstrap/tasks.sh:139-150,172-186`. → Unify install root.
+- **[high]** `SETUP_DIR="$CLONE_DIR/setup"` is a leftover from the setup→bootstrap rename (dir no longer exists). It feeds `VAULT_CONTENT="$SETUP_DIR/vault_template.j2"` (real path `bootstrap/vault_template.j2`) and `BRANCH_DIR`, so both resolve under a nonexistent `setup/`. config_writer persists the resolved-but-wrong path, so the Ansible fixup (which only rewrites empty/placeholder values) never fires and the vault role points at a missing template → vault creation fails (masked in CI, which hardcodes the correct path). `lib/core/bootstrap/config_defaults.sh:125,192`, `bootstrap/init.sh:162`, `modules/ansible/roles/vault/tasks/main.yml:60`, `tests/setup-env.sh:64`. → Rename SETUP_DIR→BOOTSTRAP_DIR, or emit the raw placeholder and let Ansible own derivation.
+- **[medium]** `bin/sot` vault_file fallback points at `$DEFAULT_ROOT/templates/vault.j2`, but there is no `templates/` dir (file is `bootstrap/vault_template.j2`). `bin/sot:84`.
+- **[low]** Symlink target drift: `/usr/sbin/SOT` (config, config_defaults, docs) vs `/usr/local/bin/SOT` (bin/sot:87 fallback) vs `/usr/local/bin/sot-bin` (tasks.sh:186). → Align to one.
+
+### D. Config format drift (v1 flat vs v2 nested)
+- **[high]** `config_writer` emits NESTED v2 runtime config, but `bin/sot:75` reads it with FLAT `parse_yaml_to_vars` and the ansible loader recursive-combines it against FLAT defaults. Flat-parsing nested YAML strips section prefixes: `ssh:\n  port:282` yields `$port` not `$ssh_port`, `$data_dir` not `$opt_data_dir`, and collides `aat/tid/runner enabled:`→`$enabled` and `branch:` (last wins, clobbering the real top-level branch). The user's chosen values never override flat defaults. `lib/core/bootstrap/config_writer.sh:14,87`, `bin/sot:75`, `modules/ansible/config/load_config.yml:27`. → Pick ONE on-disk format everywhere.
+- **[high]** Schema drift v1↔v2: keys renamed (`ssh_key_function_enabled`→`ssh.key_enabled`, `opt_data_dir`→`paths.data_dir`, `systemlink_path`→`paths.systemlink`); field-sets differ (v1 aat `_type/_runner/_description`; v2 aat `inventory_path/inventory_vars`); different repo_url/dir. No authoritative schema. v2 is dead in production (only `tests/unit/yaml.sh` + docs reference it). `config/default_config_v2.yml`, `config/default_config.yml`.
+- **[high]** AAT/TID acronyms expand differently per file: "Azure Automation Toolkit"/"Traefik Infrastructure Deployment" (v1 + bootstrap.md) vs "Ansible Automation Tools"/"Terraform Infrastructure Deployment" (v2 + README); v1 `tid_type: ansible` contradicts terraform treatment; v1 uses placeholder URLs (`yourorg/aat.git`) vs v2 real (`NiklasJavier/AAT.git`). `bin/sot` loads the stale v1 file by default. `config/default_config.yml:43-59`, `config/default_config_v2.yml:78-90`, `README.md:267-273`, `docs/bootstrap.md:164-165`.
+- **[high]** Three-to-four independent YAML parsers: canonical `yaml_parser.sh` (5 fns), `parse_plugin_yaml` (manager.sh:50-103), `load_default_config` inline regex (config_defaults.sh:38-52), plus ansible `include_vars` — each re-implements comment/CR/quote strip + colon split with divergent behavior. `lib/core/yaml_parser.sh`, `lib/plugins/manager.sh:50-103`, `lib/core/bootstrap/config_defaults.sh:38-52`, `commands/doctor.sh:225-233`. → Route all reads through `yaml_parser.sh`.
+- **[medium]** v1↔v2 flat-key mapping is not truly 1:1 despite the "backwards compatible" claim (`tools` vs `tools_install`, `ssh_key_function_enabled` vs `ssh.key_enabled`), so `load_config` yields different flat keys per schema. `lib/core/yaml_parser.sh`.
+- **[medium]** Config-mutation done three incompatible ways: `_update_config_value` sudo-sed (extensions.sh:230-239), undefined `save_plugin_state` (manager.sh:296), and `config_writer.sh` (bootstrap only). None shared. → One get/set helper.
+- **[medium]** Overrides mechanism documented but unimplemented on the shell side: `config/overrides/README.md` claims bootstrap auto-populates override files, but `tasks.sh:131` only `mkdir`s the empty dir and no shell code loads/merges overrides (only ansible merges a single `CONFIG_YAML`). `config/overrides/README.md`.
+- **[medium]** `modules/ansible/config/load_config.yml` hard-wired to FLAT schema (`sot_config.clone_dir/.username/.opt_data_dir`); fed nested v2 config, every derivation and the recursive combine silently misfire. `modules/ansible/config/load_config.yml`.
+- **[medium]** Dead "Integrationen" schema block in `default_config.yml` (`aat_type/aat_runner/aat_description`, `tid_*`, commented `mytools_*`) — superseded by extensions, never read. `config/default_config.yml:29-70`.
+- **[medium]** `scripts_dir` key generated + documented but never read — the CLI keys off `commands_dir` instead. `config/default_config.yml:15`, `docs/configuration.md:67`, `README.md:221`, `bin/sot:81,96`.
+- **[low]** `runner.sh` `get_cfg` nested-key fallbacks (`aat.enabled`) are never exercised because only flat keys are ever produced — dead defensive branches. `commands/runner.sh:106-135`.
+
+### E. Library load model & global-variable coupling
+- **[high]** Child scripts receive framework state through a 10-slot POSITIONAL contract (`CLI_METADATA_ARGS`) appended AFTER user args (`"$script" "$@" "${CLI_METADATA_ARGS[@]}"`), interpreted three incompatible ways: runner slices the LAST 10 (correct); bootstrap reads `$1/$2` (front); vault reads `$4/$5` (fixed front) — the latter two only work with ZERO user args. Config vars are also never `export`ed, so env-reading commands get empty values. Root cause of the F-theme "silent no-op" bugs and the H-theme argv secret leak. `bin/sot:100-111,310`, `commands/runner.sh:20-40`, `commands/bootstrap.sh:19-20`, `commands/vault.sh:36-37`. → Export namespaced `SOT_*` env vars; delete the positional contract.
+- **[medium]** Redundant/order-dependent sourcing: `discover_plugins` runs twice (auto at `manager.sh:580` with unset MODULES_DIR, then explicitly `bin/sot:119`); `progress.sh` sourced twice (`init.sh:24` + `bin/sot:65`); the two managers enter via different files. Guards prevent breakage but the graph does hidden double work. → Make `init.sh` the single sourcing entrypoint; remove the auto-run.
+- **[medium]** Command scaffolding boilerplate is inconsistent: the root var is named `SCRIPT_ROOT` (runner/vault/bootstrap), `ROOT_DIR` (doctor/demo), and `SOT_ROOT` (extensions/delete/update), computed with `../` vs `../..`, some guarding a missing lib and some not. `commands/*` (nine files). → One sourcing helper + one var name.
+- **[medium]** Fallback ANSI color block copy-pasted into 6 files and drifted from the canonical palette (`GREY='\033[1;90m'` vs colors.sh `GREY=$DIM`; uses `PINK` which is only a legacy alias), so output color differs depending on whether the lib loaded. `commands/vault.sh:24-31`, `commands/maintenance/{delete,cleanup_old_users}.sh`, `modules/{docker,sdkman,ansible}/install.sh`.
+- **[low]** The validate-then-assign arg-parse block is repeated ~25× in `args_parser.sh` (differing only in var name/message), plus the `while/case/shift` loop reimplemented in four files. `lib/core/bootstrap/args_parser.sh:48-315`, `commands/maintenance/{update,delete}.sh`, `commands/doctor.sh`. → `require_value` helper.
+
+### F. Broken features / bugs
+- **[high]** Alias `s`→`setup` is broken end-to-end: no `setup` command/`commands/setup.sh` exists (only `bootstrap`), so `sot s` dies with exit 127. `lib/cli/aliases.sh:25`, `bin/sot:415-419`.
+- **[high]** Interactive menu doubly broken: `show_interactive_menu` already consumes the choice via `read`, then `run_interactive_mode` issues a SECOND `read` (first keystroke lost); and the index→command mapping differs (per-category menu excluding `info` vs a flat global `sort` of ALL commands), so selecting N runs a different command than displayed. `lib/cli/registry.sh:262-316`, `bin/sot:368-400`.
+- **[high]** `sot help <cmd>` prints "Befehl nicht gefunden" for every pathless registered command (`plugins`, `help`, `version`, `aliases`, all plugin commands) because `show_command_detail` treats an empty stored path as "not found". `lib/cli/registry.sh:229-232`.
+- **[high]** `runner.sh` `sync_repo()` execs removed `commands/integrations/{aat,tid}_sync.sh`; since `runner_sync_before_run` defaults true, a plain `SOT runner aat <pb>` calls sync unconditionally and the missing file exits 127 under set -e, aborting the runner before the playbook. `commands/runner.sh:201-219`, `config/default_config.yml:77`. → Call `extension_sync`.
+- **[high]** `extensions.sh` `_update_config_value` guards on `[[ -n "${CONFIG_FILE:-}" && -f … ]]`, but `CONFIG_FILE` is never exported → guard always fails → install/remove/enable/disable never persist `<name>_enabled`. Activation is a silent no-op. `commands/extensions.sh:230-239`.
+- **[high]** `delete.sh` `create_vault_backup` reads `vault_file/vault_secret` from env (never exported) → always empty → backup silently skipped; the whole `--no-backup` feature is dead. Same cause makes CLONE_DIR/OPT_DATA_DIR/LOG_FILE always fall back to hardcoded defaults, ignoring config. `commands/maintenance/delete.sh:66-73,164-205`.
+- **[high]** `bootstrap.sh` advertises `--check`/`--tags` in @usage/@example but never parses options; it reads `modules_dir=$1/config_file=$2`, so `SOT bootstrap --tags ssh` passes garbage to trigger.sh. `commands/bootstrap.sh:6-7,18-19`.
+- **[high]** `vault.sh` reads `vault_file=${4}/vault_secret=${5}` (correct only with zero user args), so `SOT vault edit` shifts positions and yields the wrong secret; `view`/`rekey` are documented but unimplemented (always `ansible-vault edit`). `commands/vault.sh:37-38,151`.
+- **[high]** `SCRIPTS_DIR` is never resolved in `generate_dynamic_defaults`, so the literal `__GENERATE_SCRIPTS_DIR__` survives into `config.yaml` and the final overview. `lib/core/bootstrap/config_defaults.sh:105-203`, `config_writer.sh:59`, `tasks.sh:265`.
+- **[high]** `task_edit_cli` seds for `# __SOT_ROOT_PLACEHOLDER__` which no longer exists in bin/sot (removed with cli_wrapper.sh) — silent no-op that still logs "SOT_ROOT gesetzt" — then appends a hardcoded CONFIG_FILE line duplicating bin/sot:72's own default logic. `lib/core/bootstrap/tasks.sh:139-150`.
+- **[high]** Plugin enable/disable never persists: `save_plugin_state` is called (`manager.sh:297,316`) but defined nowhere (guarded by `declare -f`), so state is lost on process exit. `lib/plugins/manager.sh:296-317`.
+- **[medium]** `SOT validate` is dead routing: `bin/sot` routes it to `extensions.sh validate`, which has no such case → falls to `*)`, `extension_get` returns empty → "Unbekannter Command: validate". README's install one-liner chains `SOT validate && SOT bootstrap`, so following the README aborts. `bin/sot:465`, `commands/extensions.sh:350`, `README.md:81`.
+- **[medium]** Aliases point at non-existent commands: `cfg`→config, `log`→logs, `@l`→logs --tail, `@c`→config --show (no config/logs command registered). `lib/cli/aliases.sh:68-75`.
+- **[medium]** Multi-word alias keys (`integrations list/sync`, `aat sync/install`, `tid sync/install`) can never fire — `expand_alias_args` only looks up `$1`. `lib/cli/aliases.sh:50-61`.
+- **[medium]** `dependencies.sh` only installs sdkman/docker/ansible (TOOL_COUNT + dispatch hardcoded); any other `-tools` token is silently ignored, contradicting the free-form flag. `bootstrap/dependencies.sh:60-119`.
+- **[medium]** `extensions.sh` post-install hint prints `sot runner $name`, but runner only accepts aat/ansible/tid/terraform/list; the real path is `sot ex run <name>`. `commands/extensions.sh:179`.
+- **[low]** `dependencies.sh` uses `${BOLD}` but only defines GREEN/GREY/RED/NC locally; run standalone under set -u (as the README documents) this is an unbound-variable fatal error. `bootstrap/dependencies.sh:82`.
+- **[low]** `spinner_start` installs `trap '…' EXIT`, unconditionally clobbering any pre-existing EXIT trap for the whole process. `lib/cli/progress.sh:260`.
+
+### G. Error handling & robustness (incl. destructive-without-guards)
+- **[high]** Comment-stripping is done blindly with `line="${line%%#*}"` (yaml_parser.sh lines 33,77,120,169,249,335; config_defaults.sh:38-51) BEFORE quotes are handled, so any value containing `#` — vault secrets, passwords, URL fragments, even quoted `"ab#cd"` — is silently truncated. → Only treat whitespace-preceded `#` outside quotes as a comment.
+- **[high]** Whitespace trimming uses `xargs`, which interprets quotes/backslashes: a value like `it's` or a lone quote emits "unterminated quote" to stderr and corrupts/empties the value; also collapses internal whitespace. `lib/core/yaml_parser.sh` (lines 43-44,86-87,126-127,180-181). → Trim via bash parameter expansion.
+- **[high]** `cleanup_old_users.sh` mass-deletion keyed on unvalidated `currentUsername="${3:-}"`: if invoked with <3 args (as docs/tests imply) it is empty, so NO user matches the exclusion and ALL `/home/[A-Z]{11}` users + homes are `userdel -r`/`rm -rf`'d, gated only by one yes/no prompt with `2>/dev/null || true` swallowing failures. `commands/maintenance/cleanup_old_users.sh:29,55,61-63`. → Fail closed when empty; require user by name.
+- **[high]** `update.sh` `--force` is dead code (parsed into FORCE, never read); `update_repo()` unconditionally runs `sudo git reset --hard origin/$branch` + `git clean -fd` with no confirmation, though the header implies one exists. Same unguarded pattern in `task_clone_repository`. `commands/maintenance/update.sh:49,58,150-152`, `lib/core/bootstrap/tasks.sh:97-99`. → Implement the gate or remove the flag.
+- **[high]** The "clone-if-absent else update" git-sync pattern is reimplemented four times with divergent semantics — pull (bootstrap/init.sh, extensions/manager.sh) vs destructive `reset --hard`+`clean` (tasks.sh, update.sh) — so "update SOT" is non-destructive in one path and data-losing in another; each duplicates its own git-install guard. `bootstrap/init.sh:85-94`, `lib/core/bootstrap/tasks.sh:93-107`, `lib/extensions/manager.sh:128-149`, `commands/maintenance/update.sh:107-162`. → One `git_sync_repo` helper.
+- **[medium]** `safe_delete()` runs `sudo rm -rf` on config-derived paths (clone_dir, opt_data_dir, systemlink_path, log_file) with only a `[[ -d ]]` check — no guard against empty/`/`/`/usr`. `extensions.sh:220` similarly `rm -rf`s a config-derived dir. `commands/maintenance/delete.sh:127-158,66-72`. → Assert absolute + non-empty + min-depth + denylist.
+- **[medium]** Inconsistent strict mode: `bootstrap.sh`, `demo-progress.sh`, `trigger.sh`, `modules/docker/install.sh`, `modules/ansible/install.sh` set no `set -euo pipefail` (docker install continues after a failed `apt-get update`; bootstrap.sh assigns empty paths silently). Their siblings all set it. → Add strict mode to every executed script.
+- **[medium]** `run_tasks` unconditionally prints "✓ Installation erfolgreich abgeschlossen" even when non-critical tasks (writeConfigFile, editCliFile, installDependencies) fail, and exits 0. `lib/core/bootstrap/runner.sh:164-229`. → Track a failure flag; reflect it in footer + exit.
+- **[medium]** Colors emitted unconditionally with no TTY/NO_COLOR detection, so raw ANSI escapes leak into pipes, redirected logs, and files. `lib/core/colors.sh`, `lib/core/helpers.sh:110-154`. → Blank vars when `! -t 1` or NO_COLOR.
+- **[medium]** `get_nested_value`/`get_yaml_value` re-read and re-scan the entire file on every call, forking 3-5 subprocesses per line — quadratic if used in loops. `lib/core/yaml_parser.sh:109-143,225-297`. → Load once into an array.
+- **[low]** Under set -u several functions read bare `$1` after `shift`, aborting with "unbound variable" before the intended friendly error. `commands/extensions.sh:128,184,319`, `lib/core/bootstrap/args_parser.sh:63,72`. → Use `${1:-}`.
+- **[low]** `resolve_path` runs `cd "$(dirname …)"` NOT in a subshell (masked only because it's always called via `$(…)`). `lib/core/helpers.sh:85-105`.
+- **[low]** Quote stripping removes one leading/trailing quote independently (asymmetric/embedded quotes mishandled); only one nesting level supported; list items dropped. Inconsistent CRLF handling in the `load_config` sniffer (strips `#` but not `\r`, unlike other loops). `lib/core/yaml_parser.sh:47-50,335`.
+
+### H. Security & shell safety
+- **[high]** The Ansible-Vault master secret is written in cleartext into `config.yaml` (`vault.secret`); `.settings` is `mkdir -p` (no mode) and the file `touch`'d (no chmod) → world-readable 0644 under root's default umask, and `runner.sh` further feeds the whole file to ansible via `-e "@$config_file"`. Fully defeats ansible-vault's at-rest encryption. `lib/core/bootstrap/config_writer.sh:87`, `tasks.sh:135,111-132`, `commands/runner.sh:715`. → Store only a reference to a 0600 root-owned file; chmod 600 + mode 0700.
+- **[high]** Vault secret passed on the command line (`CLI_METADATA_ARGS` includes `vault_secret`, appended in `execute_script`), so it is world-readable via `ps aux`/`/proc/<pid>/cmdline` for the duration of any child command. `bin/sot:104,310`, `commands/vault.sh:37`, `commands/runner.sh:37`. → Never pass secrets on argv; use env or a 0600 file.
+- **[high]** `read_vault_parameter` defaults `--vault-password-file` to a persistent unencrypted `{{opt_data_dir}}/vault_pass.txt` that nothing creates 0600 or removes — a permanent plaintext copy of the vault password. `modules/ansible/roles/read_vault_parameter/tasks/main.yml:3,13`. → Use the RAM-tmpfs+shred pattern.
+- **[high]** `create_vault_backup` writes the vault secret in cleartext into `/tmp/sot-backup-<timestamp>/BACKUP_INFO.txt` and copies the vault file into world-traversable `/tmp`; dir is `mkdir -p` (0755) and files written before `chmod 600` (TOCTOU window). `commands/maintenance/delete.sh:165,184-198`. → `mkdir -m 700` in a root-only dir; never persist the secret to a text file.
+- **[high]** `read_vault_parameter` `debug: msg: "{{ vars | to_yaml }}"` dumps the ENTIRE variable namespace (db_password, api_key, vault_secret, decrypted vault vars) to stdout/logs with no `no_log`. `modules/ansible/roles/read_vault_parameter/tasks/main.yml:38-39`. → Remove; audit for `no_log`.
+- **[medium]** Bootstrap trust chain has no integrity/authenticity verification: `curl|bash` entrypoint, unpinned git clone + exec, network-downloaded `default_config.yml` parsed straight into root-driving shell vars, `curl … | bash` for SDKMAN and `sh get-docker.sh`. MITM/compromised upstream = root RCE. `bootstrap/init.sh:102`, `config_defaults.sh:27`, `modules/sdkman/install.sh:27`, `modules/docker/install.sh:33`. → Pin commits; verify checksums/signatures.
+- **[medium]** `_update_config_value` builds a `sudo sed -i "s|^${key}:.*|…|"` from an unsanitized user-supplied extension name (`${name}_enabled`); sed metacharacters/`|` can corrupt the program or retarget lines in the root-owned config. `commands/extensions.sh:230-238`. → Validate name `^[a-z0-9_]+$`; avoid sed.
+- **[medium]** Unrestricted YAML-key→shell-var assignment: `parse_yaml_to_vars` derives the var name from the key (only spaces/dashes→underscore, no allowlist) then `printf -v` — a key like `PATH:`/`IFS:`/`LD_*:` in the user-editable config silently clobbers that shell var in the running CLI. `lib/core/yaml_parser.sh:43-53`, `lib/core/bootstrap/config_defaults.sh:57-63`. → Allowlist/namespace-prefix; reject dangerous names.
+- **[medium]** Vault role writes password + decrypted content to predictable epoch-named files in shared `/dev/shm` (`.vault_pass_{{epoch}}`, `.temp_vault_content_{{epoch}}.yml`) — guessable, enabling a symlink pre-creation race against a root-written secret. `modules/ansible/roles/vault/tasks/main.yml:47,56,61`. → Use `ansible.builtin.tempfile`.
+- **[low]** `run_with_progress` runs its count arg via `eval "$count_cmd"` — latent injection the moment any config/user value flows in. `lib/cli/progress.sh:424`. → Array invocation.
+- **[low]** On a missing vault key the role substitutes hardcoded weak secrets (`db_password: default_password`, `api_key: default_api_key`, `default_server_ip`), masking a failed decrypt with predictable credentials. `modules/ansible/roles/read_vault_parameter/tasks/main.yml:23-24`. → `fail` loudly.
+- **[low]** Loader `chmod +x` then executes discovered scripts in one step (plugin installers, commands, hooks) as the invoking user (often root) — security rests entirely on filesystem perms of `/opt/SOT`; a group/world-writable tree = root RCE. `lib/plugins/manager.sh:273,350,398`, `bin/sot:307`. → Require pre-executable root-owned files; verify dir perms.
+
+### I. Docs / README / CI drift
+- **[high]** The entire `ci/` test-runner directory is documented everywhere but does not exist: `./ci/run-all-tests.sh` + `run-{helpers,yaml,bootstrap,integration}-tests.sh` with fixed counts. Real harness is `tests/run-all.sh` + `tests/{unit,integration}/*.sh`. `README.md:366-377,499`, `CONTRIBUTING.md:163-218`, `docs/development.md:139-207`, `docs/configuration.md:196`. → Mechanical find/replace to the tests/ layout.
+- **[high]** `security.yml` ShellCheck-strict steps scan nonexistent `scripts/` (57-60) and `ci/` (67-70) dirs, end in `|| true` → silently green; the real `commands/` (largest attack surface) is never strict-checked. False-green security summary. `.github/workflows/security.yml:57-70`. → Point globs at lib//commands//bootstrap//tests/.
+- **[high]** The injected-parameter contract is documented two wrong ways: `cli-reference.md`'s table claims positional `$1=command,$2=config_file…` at the FRONT, and `README` claims NAMED flags (`--config_file`, `--vault_file`) — reality is 10 metadata args appended AFTER user args. `docs/cli-reference.md:197-213`, `README.md:169-174`.
+- **[high]** `cli-reference.md` + README document a command surface removed by the integrations→extensions refactor: `SOT integrations validate`, `SOT aat/tid sync`, `SOT maintenance update/delete/cleanup_old_users`, `SOT integrations list/add`. Actual registry exposes bootstrap/doctor/vault/runner/update/delete/extensions/plugins. `docs/cli-reference.md:96-193`, `README.md:134-297`.
+- **[high]** Completions are pre-refactor: top-level verbs `setup … integrations`, an `integrations add ansible|terraform` flow, hardcoded `/etc/DevOpsToolkit` config path, `complete -F … SOT`/`#compdef SOT` while the binary is `sot`; no completion for bootstrap/doctor/extensions/plugins. Three definitions (static bash, static zsh, `registry.sh` generator) all mutually inconsistent; the static files are never installed. `completions/sot-completion.{bash,zsh}`, `lib/cli/registry.sh:322-412`. → Generate from `CLI_COMMANDS` at runtime.
+- **[medium]** README full-install quickstart chains `SOT aat sync && SOT tid sync && SOT validate && SOT bootstrap`, but post-refactor aat/tid are extensions not installed by default (bootstrap explicitly says run `sot ex install aat`) → quickstart fails as written. `README.md:76-82`.
+- **[medium]** README documents `SOT integrations add <name> <type>` as a config-template generator; no such generator exists (`extensions.sh` maps `add`→`install`, which clones an already-configured extension). `README.md:135,242,281`, `commands/extensions.sh:354`.
+- **[medium]** README links `lib/README.md` and `ci/README.md` (both absent); dir tree + CONTRIBUTING still show `lib/cli/integrations.sh`, `commands/integrations/`, `config/validators/` (gone). `README.md:322,331,484,485`, `CONTRIBUTING.md:8-35`.
+- **[medium]** `architecture.md` references `get_config_value()` (defined nowhere) and shows single-arg `load_config` (real signature needs a target array name); also names removed `setup_sot.sh`. `docs/architecture.md:60,105,133,139`, `docs/configuration.md:172-174`.
+- **[medium]** `bootstrap.md` documents nonexistent `sot debug delete` / `sot config edit` and links dead `EXTENSIONS.md`/`CONFIG.md`; `style-guide.md` links dead `BOOTSTRAP.md`. `docs/bootstrap.md:175,216,283-284`, `docs/style-guide.md:317`.
+- **[medium]** Install/config paths contradict across docs: `configuration.md` says `/etc/DevOpsToolkit/config.yaml`, `bootstrap.md` says `/opt/SOT/production/.settings/config.yaml`, README says clone `/etc/DevOpsToolkit` + symlink `/usr/sbin/SOT`, `bin/sot` defaults `/opt/SOT`. Real path is `/etc/DevOpsToolkit/setup/<branch>/.settings/config.yaml` — matching no doc. `docs/configuration.md:11`, `docs/bootstrap.md:92,164`, `README.md:86,180`.
+- **[low]** Value drift: `runner_default_mode` documented "ansible" vs code "aat"; vault-secret length "32-stellig" (configuration.md) vs "60+ Zeichen" (README). `docs/configuration.md:107,125`, `README.md:464`.
+- **[low]** `.pre-commit-config.yaml` excludes nonexistent `ci/bin/`; `development.md` references absent `.vscode/extensions.json` + `CHANGELOG.md`. `.pre-commit-config.yaml:18-22`, `docs/development.md:38,287-291`.
+- **[low]** Reverse drift: `doctor` and the whole `plugins` meta-command are documented nowhere; `demo-progress.sh` is undocumented and hidden. Inconsistent `SOT` vs `sot` casing across bin/sot usage strings + README. `docs/cli-reference.md`, `bin/sot:128,151,157`, `README.md:36,139`.
+
+### J. Dead code & leftover-from-refactor artifacts
+- **[medium]** `discover_commands` + `extract_script_metadata` (registry.sh:47-135) are never called — the entire `# @cmd/@category/@description` header convention is parsed by nothing (all commands hand-registered). Its `integrations/*)→CMD_CATEGORY=sync` branch references a removed dir and a category not in CLI_CATEGORIES.
+- **[low]** Dead helpers with zero product callers: `log_command`, `find_config_file_arg`, `run_with_timeout`, `dim`, `resolve_path`, `is_false` (tests only), legacy `parse_yaml_to_vars`/`get_yaml_value`. `lib/core/helpers.sh`, `lib/core/yaml_parser.sh`. Deprecated `PINK`/`GREY` aliases. `lib/core/colors.sh:22-23`.
+- **[low]** `run_plugin_hook` + all 6 call sites are permanently dead (no module ships a `hooks/` dir and the no-metadata branch never sets `PLUGIN_HOOKS`); `register_plugin` no-metadata fallback is unreachable (all modules have module.yml); `plugin.yml` candidates reference a file that doesn't exist. `lib/plugins/manager.sh:144,172-208,328-355`.
+- **[low]** `task_sync_extensions` (tasks.sh:196-211) defined but never wired into SETUP_TASKS (extension sync moved to `sot ex install`); `run_tasks_sync` (runner.sh:231-236) self-labelled deprecated, zero callers.
+- **[low]** cli_wrapper.sh leftovers: `# __SOT_ROOT_PLACEHOLDER__` sed target (tasks.sh:142) matches nothing; `createCliWrapperSbinLink` label (runner.sh:23, init.sh:179) still names the removed wrapper; `initalScriptOverview` typo frozen into the task-name contract (init.sh:183).
+- **[low]** `FULL`/`-full` flag parsed + echoed but drives no behavior (args_parser.sh:61-69); `SDKMAN_DEFAULT_CANDIDATES` read but never set (dependencies.sh:31); `bin/sot:3-11` banner block is an unused duplicate of `show_banner`.
+- **[low]** Half-migrated setup naming: `_SOT_SETUP_LIB_INIT_LOADED`, `SETUP_LIB_DIR`, `tests/unit/setup.sh` (guard/header still say "SOT Setup Library").
+- **[low]** Ansible dead artifacts: `roles/variables/variables/main.yml` in a non-standard subdir Ansible never loads; `protection/handlers/main.yml` empty placeholder; `protection/meta/main.yml` uses invalid `collections:` key; empty `group_vars/`/`hooks/`/`vault/` gitkeeps; large commented-out example block in `vault_template.j2:27-54`.
+
+### K. Tests
+- **[high]** `integration.sh:56` greps `sot help` output for "setup" (renamed to bootstrap) — never matches, FAILS on CI (label was updated, grep string wasn't). `tests/integration/integration.sh:56`.
+- **[high]** `integration.sh:78` checks `[[ -d commands/integrations ]]` — dir removed in the extensions refactor → FAILS. `tests/integration/integration.sh:78`.
+- **[high]** `((TESTS_FAILED++))`/`((TESTS_RUN++))` under set -euo pipefail returns exit 1 when the counter is 0, so the first failing assertion ABORTS the whole suite (masking later tests). Same footgun in `helpers.sh:22,34` and `setup.sh:24,36`; `config.sh`/`vault.sh` use the safe idiom — inconsistent. → Extract one harness with `x=$((x+1))`.
+- **[medium]** Vault "security" tests are mostly `grep` over the script SOURCE + localized German UI strings ("sicher gelöscht", "shred", "no_log: true") — they assert keywords present, not that secure deletion happens; any reformat breaks them. `tests/integration/vault.sh:86`. → Behavioral assertions via the mock ansible-vault.
+- **[medium]** Zero coverage for the refactor's headline systems: `lib/extensions/manager.sh`, `lib/plugins/manager.sh`, `commands/extensions.sh`, `config_writer/runner/tasks.sh`, `doctor.sh`, `maintenance/*`. `tests/run-all.sh:49`.
+- **[medium]** `yaml.sh` has no pass/fail counter and exits 1 on the first mismatch (fail-fast), hiding all later YAML assertions. `tests/unit/yaml.sh:20`.
+- **[medium]** README claims "69+ tests" with per-suite counts (34/5/15/15) — actual `run_test` counts are ~42/32/32/6 and cli.sh/config.sh use a different style; both total and breakdown are wrong. `README.md:54,371-374`.
+- **[low]** Expectations hardcoded to fixture values (`ssh_port=282`, `aat_enabled=true`) across yaml/setup/config/integration suites — any config edit breaks multiple suites.
+- **[low]** Whole suite requires bash ≥4 (`declare -A/-g`); on the developer's macOS bash 3.2 nothing runs (`bin/sot help` aborts with `declare: -g: invalid option`) — tests are Linux/CI-only. `tests/unit/helpers.sh:7`.
+
+### L. Ansible module quality
+- **[high]** `protection/tasks/main.yml:19` enables UFW with `policy: allow` — a default-ALLOW inbound firewall, making it a no-op (opposite of a hardening baseline). → `deny` incoming.
+- **[high]** `container_setup.yml:10` references `role: readVaultParameter` but the directory is `read_vault_parameter` (snake_case in module.yml too); Ansible role lookup is exact-match → play fails immediately, container_setup is non-functional. `modules/ansible/playbooks/container_setup.yml:10`.
+- **[high]** Vault password lifecycle is inconsistent: the vault role writes+shreds an ephemeral epoch-named pass file and `vault_secret` is a never-persisted `lookup('password','/dev/null')`, yet `read_vault_parameter` decrypts with `{{opt_data_dir}}/vault_pass.txt` which is never created — decryption is guaranteed to fail and the encryption password is unrecoverable. `modules/ansible/roles/read_vault_parameter/tasks/main.yml:3`, `roles/vault/tasks/main.yml:47`, `config/load_config.yml:74`.
+- **[high]** `common/tasks/main.yml:16` regexp is literally `^127\\.0\\.1\\.1\\s+.*` (double-backslash bytes); in a single-quoted YAML scalar the backslashes stay literal so `\\.`/`\\s` never match a real line → `lineinfile` APPENDS a duplicate `127.0.1.1` entry. `modules/ansible/roles/common/tasks/main.yml:16`.
+- **[medium]** Inverted hardening posture: `common` adds a root SSH `authorized_key` (enabling root SSH login) while the created user gets no sudo/password (unusable for admin). `modules/ansible/roles/common/tasks/main.yml:28-39`.
+- **[medium]** Debian/Ubuntu-only: hardcoded `ansible.builtin.apt` + `ppa:ansible/ansible` with no `when: ansible_os_family` guard, despite os_family being tracked in the vault template. `modules/ansible/roles/common/tasks/main.yml`, `roles/protection`, `install.sh`. → `ansible.builtin.package` + guards.
+- **[medium]** `load_config.yml:94` sets `ansible_facts: "{{ sot_config }}"`, injecting every config key as a top-level fact and abusing/clobbering the reserved `ansible_facts` namespace (fragile ordering vs fact-gathering). → Reference `sot_config.*` directly.
+- **[medium]** `trigger.sh:56-67` bakes Docker detection/installation into the generic Ansible trigger, so every host_setup run does an unrelated docker check/install. `modules/ansible/commands/trigger.sh:56-67`.
+- **[low]** `ansible.cfg:12-13` comment "Aktiviert detaillierte Fehlermeldungen" sits directly above `deprecation_warnings = False` (which disables them) — contradictory.
+- **[low]** Both playbooks declare an empty `tasks:` key above `roles:` — dead noise. `host_setup.yml:6`, `container_setup.yml:6`.
+
+---
+
+## 3. Refactor Opportunities
+
+Deduplicated across map `refactorOpportunities` + audit `recommendation`s. Effort S/M/L.
+
+**Target architecture (from the audit agents' unification proposal):** Collapse module/plugin/extension/integration to ONE "extension" concept behind a SINGLE registry with one manifest contract and one loader, where a source is either a local dir (`modules/`) or a remote git repo (aat/tid) expressed as two provider strategies behind the same interface. Merge `lib/plugins/` + `lib/extensions/` into one module; delete the rival manager, the `integration` type, and the legacy `integrations` command. Load ONE canonical config once into an associative array / exported `SOT_*` env vars (kill the positional metadata contract); use ONE YAML parser; derive ALL install paths from ONE `SOT_ROOT` constant.
+
+- **Unify extensions + plugins into one capability manager** — one registry/lifecycle/dispatch; git-repo extensions become a provider strategy; deletes the duplicated `extension_*`/`plugin_*` code and the third enable/disable in extensions.sh. **L**
+- **Pick ONE config schema (flat v1 or nested v2) and delete the other** — root cause of D-theme mis-parses/broken merges; then drop the dual-key `get_cfg` fallbacks and case-variant probing. **L**
+- **Consolidate to one YAML parser + one config-read/write path** — route all reads through `yaml_parser.sh` (fold in `parse_plugin_yaml` + `config_defaults.sh` inline loop); one get/set config-mutation helper used by extensions.sh + plugin persistence + bootstrap. **M**
+- **Fix the shared YAML line-parser once** (strip `\r`; treat only whitespace-preceded `#` outside quotes as comment; trim via parameter expansion not xargs; strip matched quote pair) — kills both HIGH data-corruption bugs. **M**
+- **Replace positional `CLI_METADATA_ARGS` with exported `SOT_*` env vars** — decouples user args from framework state; fixes bootstrap/vault/extensions/delete at once; removes the argv secret leak. **L**
+- **Unify on one install root** — eliminate `/opt/SOT` vs `/etc/DevOpsToolkit` double-clone (+ remove /opt/AAT fallback); derive CLI_FILE/MODULES_DIR/symlink from one constant so the executed CLI is the patched one; single-source install paths into docs. **M-L**
+- **Fix vault_template + `__GENERATE_*__` resolution** — repoint to `bootstrap/` (or emit raw placeholder for Ansible fixup); add SCRIPTS_DIR; fail loudly if any `__GENERATE_*__` survives into config.yaml. **S**
+- **Stop persisting VAULT_SECRET in plaintext** — store the password in a 0600 root-only file (referenced by path); `chmod 600` config.yaml + `.settings` 0700; remove `vault_secret` from argv; use `ansible.builtin.tempfile` + no_log. **M**
+- **Extract one `git_sync_repo <dir> <url> <branch> <mode>` + `ensure_git()` helper** — replaces the 4 divergent clone-or-update sites; decide once whether update is destructive; add a confirmation/`--force` gate. **M**
+- **Harden destructive maintenance** — fail-closed on empty currentUsername; denylist guard in `safe_delete`; wire `--force`; secure temp dirs (`mktemp -d`/`mkdir -m700`). **M**
+- **Unify dispatch on one table-driven resolver** — delete per-verb `case` arms; route through alias-expansion → `resolve_and_execute`; give plugin commands a real executor. **M**
+- **Wire up `discover_commands` + `@cmd` metadata; delete the hand-written registry** — single source of truth for command listing. **M**
+- **Derive aliases/help/completions from live `CLI_ALIASES`/`CLI_COMMANDS`** — delete the three stale completion definitions + dead aliases (`s`→setup, cfg/log/@l/@c, multi-word keys); fixes drift structurally. **M**
+- **Fix + consolidate the interactive menu** — one read, one index→command ordering; fix pathless-command `help`. **S**
+- **Correct Ansible hardening + bugs** — UFW deny-incoming; snake_case role refs; `/etc/hosts` regex escaping; drop the full-vars debug dump; OS abstraction (`package` + os_family); stop abusing `ansible_facts`; separate Docker from the generic trigger. **S-M**
+- **Standardize a command-scaffolding snippet + one root var name (`SOT_ROOT`)**; centralize the fallback color block; `require_value` arg helper. **S-M**
+- **Make dependency install data-driven** — loop over TOOLS dispatching to `modules/<tool>/install.sh`; compute TOOL_COUNT from the resolved list. **M**
+- **Honest task-result reporting** — track per-task exit; footer + exit reflect actual outcome; consider promoting installDependencies/writeConfigFile to critical. **S**
+- **Add strict mode + TTY/NO_COLOR awareness** to every executed script / colors.sh. **S**
+- **Tests:** fix the two stale `integration.sh` assertions (immediate green-CI win); extract `tests/lib/assert.sh` fixing the set -e counter footgun; add coverage for extensions/plugins/config_writer; convert vault.sh to behavioral assertions; recompute test counts. **S-L**
+- **Docs/CI:** global find/replace `ci/`→`tests/`; fix `security.yml` ShellCheck globs to real dirs; regenerate command docs + completions from the registry; add a docs-lint/link-checker to CI; single-source install paths; write the missing `docs/extensions.md`. **S-M**
+- **Prune dead code** — save_plugin_state/hooks lifecycle, task_sync_extensions/run_tasks_sync, __SOT_ROOT_PLACEHOLDER__/createCliWrapperSbinLink, FULL flag, dead helpers, v2 file, dead integrations config block, ansible dead artifacts. **S**
+
+---
+
+## 4. Severity Tally
+
+Counts across the deduplicated Section-2 inventory (max severity per merged entry):
+
+| Severity | Count |
+|----------|-------|
+| High     | 27    |
+| Medium   | 36    |
+| Low      | 25    |
+| **Total**| **88**|
+
+Per-theme totals: A 0H/1M/3L · B 3H/2M/1L · C 3H/1M/1L · D 4H/6M/1L · E 1H/3M/1L · F 11H/5M/2L · G 5H/5M/3L · H 5H/4M/3L · I 5H/6M/3L · J 1M/8L(grouped) · K 3H/4M/2L · L 4H/4M/2L.
+
+### Top 10 highest-impact items
+1. **Config format split (writer emits nested v2, all readers assume flat v1)** [D, high] — user-chosen settings are silently stripped/mis-merged; ssh.port/data_dir/enabled/branch collide, so real setups run on defaults. Corrupts the primary config contract.
+2. **Vault secret handled insecurely at every step** [H, high×4] — cleartext in world-readable config.yaml, on argv (`ps aux`), in a persistent `vault_pass.txt`, and in a `/tmp` backup; plus a full-vars debug dump. Collectively defeats ansible-vault entirely.
+3. **`cleanup_old_users.sh` mass-deletes all users on empty `$3`** [G, high] — the "current user" default is empty, so with <3 args it `userdel -r`/`rm -rf`s every matching home behind one prompt. Catastrophic, irreversible data loss.
+4. **Four concepts / two managers for one "capability" idea** [B, high] — module/plugin/extension/integration split across three disjoint subsystems is the central architectural debt that all other extensibility bugs (persistence, dispatch, manifest) stem from.
+5. **Two install roots + CLI-edit-vs-symlink mismatch** [C, high] — `/opt/SOT` vs `/etc/DevOpsToolkit` double-clone means users invoke an un-patched CLI and cannot locate config.yaml; poisons bootstrap correctness.
+6. **Positional `CLI_METADATA_ARGS` contract + never-exported config vars** [E/F, high] — the single design flaw that breaks `bootstrap --check`, `vault edit`, extensions enable/disable, and delete backup, and leaks the vault secret on argv.
+7. **`runner.sh` sync_repo calls removed integrations scripts** [F, high] — because `runner_sync_before_run` defaults true, the headline `SOT runner aat <pb>` aborts (exit 127) before any playbook runs.
+8. **UFW `policy: allow`** [L, high] — the hardening role installs a firewall that permits everything by default: a security control that is worse than absent.
+9. **Vault password lifecycle mismatch + broken container_setup role ref** [L, high] — encrypt uses an ephemeral secret, decrypt reads a file that is never created; the container play also references a nonexistent role — the Ansible vault/container flow cannot work end-to-end.
+10. **YAML parser `#`-truncation + xargs corruption** [G, high] — the shared parser silently mangles any value containing `#`, quotes, or backslashes (secrets, passwords, URLs) — a data-integrity bug under every config read.
+
+_Runner-up (docs/CI): the pervasive `ci/`-directory drift + `security.yml` false-green + two red integration-test assertions mean CI reports success while the documented workflow and security scan are inoperative._

--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -1,4 +1,8 @@
-# SOT — Refactoring-Plan
+# SOT — Refactoring-Plan (Bash-in-place)
+
+> ⚠️ **SUPERSEDED / historisch.** Die Richtung wurde geändert: SOT wird **nicht** in Bash refactored, sondern **komplett auf ein natives Java-CLI (Quarkus + GraalVM) neugebaut** — siehe **[`java-quarkus-rewrite-plan.md`](./java-quarkus-rewrite-plan.md)**.
+>
+> Dieses Dokument bleibt als **Kontext** erhalten: Es dokumentiert Zweck, Ist-Diagnose und die 3 Grundursachen. Die dort beschriebenen 8 Bash-Phasen sind **obsolet**; die **Befund-/Capability-Inventur** ([`refactoring-findings.md`](./refactoring-findings.md)) bleibt hingegen die **funktionale Spezifikation + Regressions-Checkliste** für den Java-Neubau (jede heute vorhandene Fähigkeit muss im Java-CLI erhalten bleiben; jeder der 88 Bugs muss im Neubau strukturell verschwinden).
 
 > Erstellt aus einer tiefgehenden Analyse des gesamten Repos (10 Subsystem-Kartierungen + 5 Querschnitts-Audits, 88 deduplizierte Befunde: **27 High / 36 Medium / 25 Low**). Dieser Plan beschreibt **Zweck → Ist-Zustand → Ziel-Architektur → phasenweisen Umbau**. Er ist die Grundlage für die Umsetzung; es wurde noch **kein Produktivcode geändert**.
 >

--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -1,0 +1,352 @@
+# SOT — Refactoring-Plan
+
+> Erstellt aus einer tiefgehenden Analyse des gesamten Repos (10 Subsystem-Kartierungen + 5 Querschnitts-Audits, 88 deduplizierte Befunde: **27 High / 36 Medium / 25 Low**). Dieser Plan beschreibt **Zweck → Ist-Zustand → Ziel-Architektur → phasenweisen Umbau**. Er ist die Grundlage für die Umsetzung; es wurde noch **kein Produktivcode geändert**.
+>
+> Vollständige Befundliste mit `file:line` für jeden der 88 Befunde: [`docs/refactoring-findings.md`](./refactoring-findings.md) (Evidenz-Basis dieses Plans).
+
+---
+
+## 0. Zweck des Repos — was SOT ist
+
+**SOT (Server Operation Toolkit)** ist ein **Bash-basiertes DevOps-Framework für reproduzierbares Setup und den Betrieb von Linux-Servern** (~10 000 Zeilen Shell). Der Kern liefert:
+
+- ein **einheitliches CLI** (`bin/sot`, aufgerufen als `SOT <befehl>`), das Befehle auf Skripte auflöst und ausführt,
+- eine **Shared Library** (`lib/`) mit Kernfunktionen (Farben, Logging, YAML-Parser) und CLI-Infrastruktur,
+- ein **Bootstrap-System** (`bootstrap/` + `lib/core/bootstrap/`), das per `curl | bash` einen Server klont, konfiguriert und Tools installiert,
+- ein **Erweiterungs-System** (heute doppelt: `plugins/` für lokale `modules/` + `extensions/` für externe Git-Repos wie AAT/TID),
+- **Module** für Ansible (Host-/Container-Hardening, Vault), Docker und SDKMAN,
+- **Config** als YAML, **Tests** (Bash-Harness) und **CI** (GitHub Actions).
+
+**Wertversprechen:** Ein einziges CLI + eine deklarative Config bringen einen frischen Linux-Host reproduzierbar in einen definierten Zustand (SSH, Firewall, User, Secrets via Ansible-Vault, Container), erweiterbar über Plugins/Extensions.
+
+---
+
+## 1. Ist-Zustand — Diagnose
+
+Das Repo befindet sich **mitten in drei unfertigen Umbenennungen**, deren Artefakte sich gegenseitig verstärken:
+
+1. `setup` → `bootstrap` (Library + Kommando)
+2. `integrations` → `extensions` (Erweiterungs-System)
+3. Config **flach v1** → **verschachtelt v2**
+4. Entfernung von `cli_wrapper.sh`
+
+Die Umbenennungen wurden **nirgends vollständig durchgezogen**. Ergebnis: 88 Befunde, davon **27 High** — darunter **Datenverlust-Risiken** (Massen-User-Löschung), **Secret-Leaks** (Vault-Passwort im Klartext an mehreren Stellen) und **komplett kaputte Kern-Pfade** (`SOT runner` bricht ab, Config-Werte des Nutzers werden ignoriert). CI meldet trotzdem grün, weil Security-Scan und zwei Integrationstests ins Leere zeigen.
+
+**Kernaussage:** Fast alle 88 Befunde sind **Symptome von 3 Grundursachen**. Wer die 3 Grundursachen sauber auflöst, eliminiert den Großteil der Einzelbugs strukturell — statt sie einzeln zu flicken.
+
+---
+
+## 2. Die drei Grundursachen (Root Causes)
+
+| # | Grundursache | Was passiert | Betroffene Befunde |
+|---|---|---|---|
+| **R1** | **Config-Schema-Split** | `config_writer` schreibt **verschachteltes v2**, aber `bin/sot` liest es mit dem **flachen** Parser und der Ansible-Loader merged gegen **flache** Defaults. Verschachtelte Keys verlieren ihr Präfix (`ssh.port` → `$port` statt `$ssh_port`), `enabled`/`branch` kollidieren. **Die vom Nutzer gewählten Werte überschreiben nie die Defaults.** Dazu **3–4 parallele YAML-Parser** mit divergentem Verhalten und zwei inkompatible Default-Dateien. | Thema D (11), Teile von G, K, L |
+| **R2** | **Extensibility-Split** | **Vier Begriffe** (module/plugin/extension/integration) für **ein** Konzept, umgesetzt in **drei disjunkten Subsystemen** (`lib/plugins/manager.sh`, `lib/extensions/manager.sh`, `commands/extensions.sh`) ohne gemeinsamen Code — getrennte Discovery, Config, Lifecycle, CLI-Pfad, sogar getrennte Sourcing-Einstiegspunkte. Persistenz fehlt (`save_plugin_state` nirgends definiert; `_update_config_value`-Guard schlägt immer fehl). | Thema B (6), Teile von A, F |
+| **R3** | **Framework-State-Übergabe** | Kind-Skripte bekommen Framework-Zustand über einen **10-Slot-Positional-Contract** (`CLI_METADATA_ARGS`), **hinter** die User-Args gehängt — von drei Skripten **unterschiedlich** interpretiert (nur korrekt bei null User-Args). Config-Variablen sind **nie `export`ed**, also lesen env-basierte Kommandos leere Werte. Zusätzlich landet das **Vault-Secret auf der Kommandozeile** (`ps aux`). | Thema E (5), Große Teile von F + H |
+
+Sekundäre, aber eigenständige Ursachen:
+
+| # | Ursache | Wirkung |
+|---|---|---|
+| **R4** | **Zwei Install-Roots** (`/opt/SOT` vs `/etc/DevOpsToolkit`) + `/opt/AAT`-Fallback | Doppel-Clone; der gepatchte CLI und der verlinkte CLI sind **verschiedene Bäume**; Config nicht auffindbar |
+| **R5** | **Unsicheres Secret-Handling** | Vault-Passwort im Klartext in world-readable `config.yaml`, auf argv, in persistenter `vault_pass.txt`, in `/tmp`-Backup, plus Full-Vars-Debug-Dump |
+| **R6** | **Fehlende gemeinsame Helfer** | Git-Sync 4× reimplementiert (mal harmlos, mal `reset --hard`), Farb-Fallback 6× kopiert, Arg-Parsing 25×, Dispatch doppelt |
+| **R7** | **Docs/CI/Tests-Drift** | Docs beschreiben ein Repo, das nicht mehr existiert (`ci/`, `integrations`, alte Pfade); CI grün trotz kaputter Scans/Tests |
+
+---
+
+## 3. Ziel-Architektur
+
+```mermaid
+graph TD
+    subgraph Entry
+      A[bin/sot<br/>nur Dispatch + Meta-Flags]
+    end
+    subgraph Core["lib/core — Foundation"]
+      Y[yaml.sh<br/>EINE Parser-Implementierung]
+      C[config.sh<br/>load once → SOT_CFG assoc-array<br/>+ export SOT_* env]
+      COL[colors.sh<br/>TTY/NO_COLOR-aware]
+      H[helpers.sh<br/>log/err + git_sync_repo + require_value]
+    end
+    subgraph CLI["lib/cli"]
+      R[registry.sh<br/>EINE table-driven Auflösung]
+      AL[aliases.sh<br/>aus CLI_ALIASES generiert]
+      P[progress.sh]
+    end
+    subgraph Ext["lib/ext — EIN Capability-Manager"]
+      M[manager.sh<br/>eine Registry, ein Manifest,<br/>ein Lifecycle]
+      LP[provider: local dir<br/>modules/*]
+      RP[provider: remote git<br/>aat/tid]
+      M --> LP
+      M --> RP
+    end
+    subgraph Boot["Bootstrap"]
+      B[bootstrap/init.sh + lib/core/bootstrap/*<br/>EIN Install-Root SOT_ROOT]
+    end
+    A --> R --> CMD[commands/*<br/>lesen SOT_* env,<br/>eigenes Arg-Parsing]
+    A --> M
+    R -.liest.-> C
+    C --> Y
+    CMD --> Core
+    M --> Core
+    B --> Core
+```
+
+**Leitprinzipien der Ziel-Architektur:**
+
+1. **Ein Config-Schema, ein Parser, ein Ladepfad.** Config wird **einmal** in ein Assoziativ-Array + `export SOT_*` geladen. Jeder Lesezugriff geht durch `lib/core/yaml.sh`. Kein zweiter Parser, keine zweite Default-Datei.
+2. **Ein Erweiterungs-Konzept.** module = plugin = extension = "**Extension**". Eine Registry, ein Manifest-Contract (`module.yml`), ein Lifecycle. Eine Extension bezieht ihren Code entweder aus einem **lokalen Verzeichnis** oder einem **entfernten Git-Repo** — zwei Provider-Strategien hinter **einem** Interface. `integration`-Typ und Legacy-`integrations`-Kommando entfallen.
+3. **Kein Positional-Metadata-Contract.** Framework-Zustand fließt ausschließlich über **exportierte `SOT_*`-Env-Variablen**. Kommandos parsen ihre eigenen User-Args frei. Secrets nie auf argv.
+4. **Ein Install-Root.** Alle Pfade werden aus **einer** `SOT_ROOT`-Konstante abgeleitet. Der ausgeführte CLI **ist** der gepatchte/verlinkte CLI.
+5. **Secrets-by-reference.** Config speichert nur einen **Verweis** auf eine `0600` root-owned Passwortdatei; `config.yaml` selbst `chmod 600`; kein Secret in argv/logs/tmp; Ansible mit `no_log` + `tempfile`.
+6. **DRY-Foundation.** Ein `git_sync_repo`, ein `require_value`, ein Farb-Fallback, ein Scaffolding-Snippet, eine Test-Assert-Bibliothek. Strict-Mode (`set -euo pipefail`) in **jedem** ausgeführten Skript.
+7. **Generierte Wahrheit.** Hilfe, Aliase, Completions und Command-Docs werden **aus der lebenden Registry generiert**, nicht handgepflegt.
+
+---
+
+## 4. Offene Entscheidungen (vor Umsetzungsstart bestätigen)
+
+Diese Weichen bestimmen das Zielbild. Ich gebe eine begründete Empfehlung; bitte bestätigen oder umlenken.
+
+| # | Entscheidung | Empfehlung | Begründung |
+|---|---|---|---|
+| **E1** | **Config-Schema** flach v1 **oder** verschachtelt v2? | **Verschachtelt v2** als kanonisch; `bin/sot`-Parser flacht deterministisch zu `section_key` ab. `default_config.yml` (v1) löschen. | `config_writer` erzeugt bereits v2; README/Docs/Tests referenzieren v2; verschachtelt skaliert besser. Der einzige Grund für v1 (weniger Parser-Aufwand) entfällt, sobald es nur **einen** Parser gibt. |
+| **E2** | **Install-Root** `/opt/SOT` **oder** `/etc/DevOpsToolkit`? | **`/opt/SOT`** als Programm-Root; Runtime-State (`config.yaml`, `.settings`, Logs) unter `/opt/SOT/<branch>/` bzw. einem dedizierten Data-Dir. `/opt/AAT`-Fallback entfernen. | `/opt` ist der FHS-Ort für Zusatz-Software; `/etc` ist für Config, nicht für Programme. `bin/sot` defaultet ohnehin auf `/opt/SOT`. Ein Root statt Doppel-Clone. |
+| **E3** | **Umsetzungsstil** Big-Bang **oder** inkrementell (Phasen-PRs)? | **Inkrementell**, eine PR pro Phase, jede grün. | 27 High-Bugs + kaputtes CI ⇒ zuerst ein vertrauenswürdiges Sicherheitsnetz, dann tragende Umbauten. Big-Bang wäre unreviewbar. |
+| **E4** | **Migration bestehender Installationen** unterstützen? | **Nein** (Greenfield-Annahme), sofern keine produktiven SOT-Installationen existieren. Sonst: ein `sot migrate`-Einmalskript in Phase 1. | Reduziert Komplexität massiv. **Bitte bestätigen, dass es keine Installationen im Feld gibt, die einen automatischen Config-Migrationspfad brauchen.** |
+| **E5** | **Sprache der Doku/Commit-Messages** | **Deutsch** (Repo-Konvention beibehalten). | Konsistenz mit bestehender Doku und Git-Historie. |
+
+---
+
+## 5. Refactoring in Phasen
+
+Jede Phase = eine reviewbare Einheit mit **Abnahme-Gate** (grün, bevor die nächste startet). Aufwand: **S** ≤ 0.5 Tag, **M** ≈ 1–2 Tage, **L** ≈ 3–5 Tage (Richtwerte für eine Person).
+
+---
+
+### Phase 0 — Sicherheitsnetz & Stop-the-Bleeding *(Aufwand: M · Risiko: niedrig · keine Abhängigkeiten)*
+
+Zweck: **Vertrauenswürdiges CI** und **Entschärfung der katastrophalen Bugs**, bevor irgendetwas Tragendes angefasst wird. Reine Bug-/Guard-Fixes, keine Architektur.
+
+| Task | Befund | Aufwand |
+|---|---|---|
+| `cleanup_old_users.sh`: bei leerem `currentUsername` **fail-closed**, User zwingend per Name verlangen | G/high `cleanup_old_users.sh:29,55,61-63` | S |
+| `safe_delete()`: Denylist-Guard (absolut, nicht-leer, Mindest-Tiefe, kein `/`,`/usr`,…) vor jedem `sudo rm -rf` | G/med `delete.sh:127-158` | S |
+| `update.sh`: `--force`-Gate implementieren **oder** Flag entfernen; destruktives `git reset --hard`/`clean` hinter Bestätigung | G/high `update.sh:49,58,150-152` | S |
+| Zwei rote Integrationstests fixen (`grep "setup"`→`bootstrap`; `commands/integrations`-Check entfernen) | K/high `integration.sh:56,78` | S |
+| Test-Harness extrahieren `tests/lib/assert.sh` — `set -e`-Counter-Footgun (`((x++))` → `x=$((x+1))`) an allen Stellen | K/high `helpers.sh:22`, `setup.sh:24`, `yaml.sh:20` | M |
+| `security.yml`: ShellCheck-Globs auf **reale** Verzeichnisse (`lib/ commands/ bootstrap/ tests/`), `|| true` entfernen → kein False-Green mehr | I/high `security.yml:57-70` | S |
+
+**Gate:** `tests/run-all.sh` grün · `security.yml` läuft strikt gegen echten Code · manuelle Prüfung: `cleanup_old_users` ohne Argument löscht nichts.
+
+---
+
+### Phase 1 — Foundational Contracts *(Aufwand: L · Risiko: hoch · blockiert 2,3,5,7)*
+
+Zweck: Die **drei Grundursachen R1/R3/R4** auflösen. Das ist der load-bearing Umbau; danach werden viele Einzelbugs gegenstandslos.
+
+**1a — Ein YAML-Parser, korrekt (R1-Teil 1).**
+- `lib/core/yaml_parser.sh` zur **einzigen** Implementierung machen; `parse_plugin_yaml` (manager.sh) und den Inline-Loop in `config_defaults.sh` darauf umstellen.
+- Parser-Korruption fixen: `\r` strippen; **nur** whitespace-vorangestelltes `#` außerhalb von Quotes als Kommentar; Trimmen via Parameter-Expansion statt `xargs`; gepaarte Quotes entfernen.
+- Var-Namen-Zuweisung **allowlisten/namespacen** (kein Clobbern von `PATH`/`IFS`/`LD_*`).
+- *Befunde:* G/high (`#`-Truncation, `xargs`), D/high (4 Parser), H/med (Var-Injection).
+
+**1b — Ein Config-Schema + ein Ladepfad (R1-Teil 2, hängt an E1).**
+- Kanonisches Schema festlegen (Empfehlung v2). `lib/core/config.sh`: **einmal** laden → `SOT_CFG`-Assoziativ-Array + deterministisches `export SOT_*`.
+- `bin/sot`, `config_defaults.sh`, `modules/ansible/config/load_config.yml`, `runner.sh get_cfg` auf **diesen einen** Pfad umstellen. Zweite Default-Datei + toten Integrations-Block + `scripts_dir` löschen.
+- *Befunde:* D/high×3, D/med×4.
+
+**1c — Positional-Contract → exportierte Env (R3).**
+- `CLI_METADATA_ARGS` löschen; `execute_script` ruft Kommandos **ohne** angehängte Metadaten. Framework-State kommt aus `SOT_*`-Env.
+- `bootstrap.sh`, `vault.sh`, `delete.sh`, `extensions.sh` auf Env umstellen + **eigenes** Arg-Parsing (damit `--check`/`--tags`/`edit` wieder funktionieren).
+- Vault-Secret aus argv entfernen (Übergang zu Datei-Referenz, Vollausbau in Phase 4).
+- *Befunde:* E/high, F/high (`bootstrap --check`, `vault edit`, extensions-Persistenz, delete-Backup), H/high (argv-Leak).
+
+**1d — Ein Install-Root (R4, hängt an E2).**
+- Doppel-Clone `/opt/SOT` vs `/etc/DevOpsToolkit` eliminieren; alle Pfade aus **einer** `SOT_ROOT`-Konstante ableiten (CLI-Datei, Modules, Symlink). `/opt/AAT`-Fallback entfernen.
+- `SETUP_DIR`→`BOOTSTRAP_DIR` (toter `setup/`-Pfad), `vault_template`-Pfad reparieren, `__GENERATE_SCRIPTS_DIR__` auflösen, `task_edit_cli`-Toter-Sed entfernen.
+- *Befunde:* C/high×3, C/med, F/high (SCRIPTS_DIR, task_edit_cli).
+
+**Gate:** `SOT bootstrap` schreibt Config, die `SOT` **wieder korrekt liest** (Roundtrip-Test); `SOT vault edit`, `SOT bootstrap --tags x` funktionieren; ein Install-Root; neue Unit-Tests für Parser-Edgecases (`#`, Quotes, CRLF) grün.
+
+---
+
+### Phase 2 — Extensibility vereinheitlichen *(Aufwand: L · Risiko: hoch · hängt an Phase 1)*
+
+Zweck: **R2** auflösen — ein Capability-Manager statt zwei.
+
+- `lib/plugins/` + `lib/extensions/` → **`lib/ext/manager.sh`**: eine Registry, ein Lifecycle (enabled/list/info/run/install/remove), zwei Provider-Strategien (local dir / remote git).
+- **Manifest-Contract** (`module.yml`) und Parser in Übereinstimmung bringen: entweder auf flache Keys beschränken **oder** echtes YAML + versioniertes Schema + Validierung bei Discovery. `requirements/config/playbooks/roles/templates` entweder konsumieren oder streichen.
+- **Persistenz reparieren**: ein `config_set`-Helfer (aus Phase 1) für `<name>_enabled`; `save_plugin_state` real implementieren; die **dritte** enable/disable-Kopie in `extensions.sh` löschen.
+- `integration`-Typ + Legacy-`integrations`-Kommando + tote Multi-Wort-Aliase entfernen. `runner.sh sync_repo` → `extension_sync` (behebt den `SOT runner`-Abbruch).
+- *Befunde:* B/high×3, B/med×2, F/high (runner sync, extensions-Persistenz, plugin-Persistenz), F/med (validate-Routing).
+
+**Gate:** `SOT ext install aat` → klont, aktiviert, **persistiert**; `SOT runner aat <pb>` läuft durch; ein Discovery-Pfad; Manifest-Validierung schlägt bei kaputtem `module.yml` fehl; neue Tests für den Manager.
+
+---
+
+### Phase 3 — Dispatch & CLI-Oberfläche *(Aufwand: M · Risiko: mittel · hängt an Phase 1–2)*
+
+Zweck: **Eine** Auflösung, generierte Oberfläche.
+
+- **Ein table-driven Dispatcher**: Per-Verb-`case`-Arme (`doctor/update/delete/plugins/integrations/validate`) löschen; alles über Alias-Expansion → `resolve_and_execute`. Doppelte Auflösungsmechanik entfernen.
+- Aliase/Hilfe/Completions **aus `CLI_ALIASES`/`CLI_COMMANDS` generieren**; drei divergente Completion-Definitionen + tote Aliase (`s`→setup, `cfg`/`log`/`@l`/`@c`) entfernen.
+- Interaktives Menü fixen (ein `read`, konsistentes Index→Command-Mapping); `sot help <pathless-cmd>` reparieren.
+- Entscheiden: `discover_commands` + `@cmd`-Metadaten verdrahten **oder** löschen (aktuell tot).
+- *Befunde:* A/med + A/low×3, F/high (Menü, pathless help), F/high (`s`→setup), I/high (Completions), J/med (discover_commands).
+
+**Gate:** `SOT help`, `SOT <cmd> --help`, `SOT --interactive`, Completions decken **genau** die registrierten Kommandos ab (Test, der Registry gegen Completions/Docs difft).
+
+---
+
+### Phase 4 — Security-Härtung *(Aufwand: M · Risiko: mittel · hängt an Phase 1)*
+
+Zweck: **R5** und die restlichen H-Befunde.
+
+- **Vault-Secret-Lifecycle**: Passwort in `0600` root-owned Datei; Config speichert nur den **Pfad**; `config.yaml` `chmod 600`, `.settings` `0700`; kein Secret auf argv (bereits in 1c begonnen); Ansible via `ansible.builtin.tempfile` + `no_log`; Full-Vars-`debug`-Dump entfernen; schwache Default-Secrets → `fail`.
+- **Bootstrap-Trust**: Git-Clone auf Commit pinnen; heruntergeladene Installer (SDKMAN/Docker) per Checksum/Signatur verifizieren.
+- **sed-Injection** in `_update_config_value`: Name gegen `^[a-z0-9_]+$` validieren, `sed` meiden.
+- `eval` in `run_with_progress` durch Array-Aufruf ersetzen.
+- *Befunde:* H/high×5, H/med×4, H/low×3.
+
+**Gate:** `grep`-basierter Secret-Scan über generierte `config.yaml` + `ps aux` während `SOT runner` findet **kein** Klartext-Passwort; gitleaks grün; neue behaviorale Vault-Tests.
+
+---
+
+### Phase 5 — Ansible-Modul korrigieren *(Aufwand: M · Risiko: mittel · hängt an Phase 1)*
+
+Zweck: Die Ansible-Seite tatsächlich funktionsfähig + hardening-korrekt machen.
+
+- **UFW `policy: deny`** (statt `allow`) — Firewall härtet, statt alles zu erlauben.
+- Rollen-Referenz `readVaultParameter` → `read_vault_parameter` (container_setup lauffähig).
+- Vault-Passwort-Lifecycle zwischen `vault`/`read_vault_parameter` **angleichen** (aktuell verschlüsselt/entschlüsselt mit verschiedenen Quellen → garantierter Fehlschlag).
+- `/etc/hosts`-Regex-Escaping fixen (Doppel-Backslash → Duplikat-Append).
+- OS-Abstraktion (`ansible.builtin.package` + `when: ansible_os_family`), `ansible_facts`-Missbrauch beenden, Docker aus dem generischen Trigger lösen, root-SSH-Key/sudo-Posture korrigieren.
+- *Befunde:* L/high×4, L/med×4, L/low×2.
+
+**Gate:** `host_setup.yml` + `container_setup.yml` laufen gegen einen Wegwerf-Container durch; Vault encrypt→decrypt Roundtrip grün; `ansible-lint` grün.
+
+---
+
+### Phase 6 — DRY-Konsolidierung *(Aufwand: M · Risiko: niedrig · hängt an Phase 1)*
+
+Zweck: **R6** — duplizierte Logik in gemeinsame Helfer ziehen.
+
+- **`git_sync_repo <dir> <url> <branch> <mode>`** + `ensure_git()` — ersetzt 4 divergente Clone-oder-Update-Stellen; einmal entscheiden, ob Update destruktiv ist (+ Gate).
+- **`require_value`**-Arg-Helfer (ersetzt ~25× validate-then-assign) + ein `while/case/shift`-Muster.
+- **Ein Farb-Fallback-Block** zentralisieren (statt 6× kopiert & gedriftet); **ein** Scaffolding-Snippet + **ein** Root-Var-Name (`SOT_ROOT`).
+- Dependency-Install **datengetrieben** (Loop über `TOOLS` → `modules/<tool>/install.sh`), `TOOL_COUNT` berechnet.
+- **Ehrliches Task-Reporting**: Per-Task-Exit tracken; Footer + Exit-Code spiegeln echtes Ergebnis (kein „erfolgreich" bei fehlgeschlagenen Tasks).
+- Strict-Mode + TTY/`NO_COLOR`-Awareness in **jedem** ausgeführten Skript / `colors.sh`.
+- *Befunde:* G/high (git-sync), G/med (strict-mode, Task-Reporting, Farben), E/med×3, E/low, F/med (deps).
+
+**Gate:** Nur noch **eine** git-sync-Funktion (grep-Nachweis); `NO_COLOR=1 SOT help | cat` enthält keine ANSI-Codes; fehlgeschlagener Task → Exit ≠ 0.
+
+---
+
+### Phase 7 — Docs, Completions, Test-Abdeckung *(Aufwand: M · Risiko: niedrig · hängt an Phase 1–3)*
+
+Zweck: **R7** — Doku und Tests an die reale (jetzt konsolidierte) Architektur angleichen.
+
+- Globales `ci/` → `tests/` in README/CONTRIBUTING/docs; entfernte Kommando-Oberfläche + falschen Injected-Param-Contract korrigieren; tote Links (`lib/README.md`, `EXTENSIONS.md`, …) fixen; Install-Pfade **single-source** (ein Include/Variable).
+- Command-Docs + Completions **aus der Registry generieren** (Phase 3 liefert die Quelle); `docs/extensions.md` schreiben.
+- Test-Abdeckung für die Headline-Systeme ergänzen: `lib/ext/manager.sh`, `config_writer/runner/tasks`, `doctor`, `maintenance/*`; `vault.sh`-Tests auf **behaviorale** Assertions (Mock-`ansible-vault`) statt Source-`grep`; Test-Zahlen im README neu berechnen.
+- **Doc-/Link-Lint** in CI aufnehmen (verhindert erneute Drift strukturell).
+- macOS/bash-3.2-Situation dokumentieren oder Guard verbessern.
+- *Befunde:* I/high×5, I/med×6, I/low×3, K/med×3, K/low×2.
+
+**Gate:** README-Befehle stimmen mit Registry überein (automatisierter Diff-Test); Link-Checker grün; Test-Zahlen im README = tatsächliche.
+
+---
+
+### Phase 8 — Dead-Code-Sweep *(Aufwand: S · Risiko: niedrig · laufend + final)*
+
+Toten Code opportunistisch in jeder Phase entfernen, am Ende ein Sweep für den Rest:
+`save_plugin_state`/`run_plugin_hook`-Lifecycle, `task_sync_extensions`/`run_tasks_sync`, `__SOT_ROOT_PLACEHOLDER__`/`createCliWrapperSbinLink`, `FULL`-Flag, tote Helfer (`log_command`, `find_config_file_arg`, `run_with_timeout`, `resolve_path`, deprecated `PINK`/`GREY`), v2/v1-Restdatei, toter Integrations-Config-Block, Ansible-Artefakte (`roles/variables/variables/`, leere Handler, invalides `meta/collections`), Setup-Reste (`_SOT_SETUP_LIB_INIT_LOADED`, `SETUP_LIB_DIR`).
+*Befunde:* Thema J (9 gruppiert) + Reste aus allen Phasen.
+
+**Gate:** `shellcheck`/`shfmt` grün; keine Referenzen mehr auf entfernte Symbole (`grep`-Nachweis).
+
+---
+
+## 6. Sequencing & Abhängigkeiten
+
+```
+Phase 0 (Sicherheitsnetz)  ── unabhängig, ZUERST
+        │
+        ▼
+Phase 1 (Foundational: R1/R3/R4)  ── load-bearing, blockiert alles Folgende
+        │
+        ├───────────────┬───────────────┬───────────────┐
+        ▼               ▼               ▼               ▼
+Phase 2 (Ext R2)   Phase 4 (Sec R5)  Phase 5 (Ansible) Phase 6 (DRY R6)
+        │                                               (4/5/6 parallelisierbar)
+        ▼
+Phase 3 (Dispatch)
+        │
+        ▼
+Phase 7 (Docs/Tests)  ── braucht die konsolidierte Oberfläche aus 1–3
+        │
+        ▼
+Phase 8 (Dead-Code-Sweep)  ── final + laufend
+```
+
+**Kritischer Pfad:** 0 → 1 → 2 → 3 → 7. Phasen 4, 5, 6 können nach Phase 1 **parallel** von weiteren Personen bearbeitet werden.
+
+---
+
+## 7. Quick Wins (erste PR, sofort)
+
+Höchster Nutzen bei geringstem Risiko — deckt sich mit **Phase 0** plus zwei triviale Fixes aus Phase 2/3:
+
+1. `cleanup_old_users` fail-closed (Datenverlust-Stopp) — **S**
+2. Zwei rote Integrationstests + Assert-Counter-Footgun (**CI wird ehrlich**) — **M**
+3. `security.yml`-Globs (**Security-Scan wird ehrlich**) — **S**
+4. `runner.sh sync_repo` → `extension_sync` (**`SOT runner` läuft wieder**) — **S**
+5. UFW `deny` (**Firewall härtet wirklich**) — **S**
+
+> Diese fünf beseitigen 4 High-Bugs und stellen ein vertrauenswürdiges CI her — die Basis, auf der alle tragenden Umbauten sicher stattfinden.
+
+---
+
+## 8. Verifikationsstrategie
+
+- **Pro Phase ein Gate** (oben je Phase definiert) — die nächste Phase startet erst bei grün.
+- **Roundtrip-Tests** als zentrale Absicherung von Phase 1: `bootstrap` schreibt → `SOT` liest → Werte identisch; Vault encrypt → decrypt → identisch.
+- **Registry-als-Quelle-Tests**: automatisierter Diff Registry ↔ Completions ↔ Docs (verhindert erneute Drift).
+- **Behaviorale statt textuelle Tests** für Security-kritische Pfade (Mock-`ansible-vault`, `ps`/`grep`-Secret-Scan).
+- **CI muss ehrlich werden, bevor sie als Gate zählt** (Phase 0) — sonst validiert man gegen ein grünes Placebo.
+- **Manuelle Smoke-Runs** gegen einen Wegwerf-Container für Bootstrap/Ansible (Phasen 1, 5).
+
+---
+
+## 9. Risiken & Gegenmaßnahmen
+
+| Risiko | Gegenmaßnahme |
+|---|---|
+| Phase 1 ist groß und tragend — Regressionsgefahr | In 1a–1d unterteilen, jede mit eigenen Tests; Roundtrip-Test als Netz; inkrementell (E3) |
+| Bestehende Installationen im Feld brechen bei Schema-/Pfadwechsel | E4 klären; falls nötig `sot migrate`-Einmalskript in Phase 1 |
+| „Ein Parser/ein Manager" verliert versehentlich ein genutztes Feature | Vor Löschen jeweils Nutzungs-`grep`; Feature-Parität als Testfall festhalten |
+| Security-Fixes ändern Vault-Format → alte Vaults unlesbar | Vault-Rekey-Pfad (`sot vault rekey`, in Phase 3/4 zu implementieren) dokumentieren |
+| Reihenfolge-Abweichung (jemand startet Phase 3 vor 1) | Abhängigkeitsgraph (§6) im PR-Template referenzieren |
+
+---
+
+## 10. Anhang — Befund-Index → Phase
+
+| Thema | Kurzbeschreibung | High/Med/Low | Phase |
+|---|---|---|---|
+| A | Command-Dispatch & Routing | 0/1/3 | 3 |
+| B | Plugin/Extension/Integration/Module-Overlap | 3/2/1 | 2 |
+| C | Pfad- & Installations-Drift | 3/1/1 | 1d |
+| D | Config-Format-Drift (v1/v2) | 4/6/1 | 1a/1b |
+| E | Library-Load-Modell & Global-Coupling | 1/3/1 | 1c / 6 |
+| F | Kaputte Features / Bugs | 11/5/2 | 1c / 2 / 3 |
+| G | Error-Handling & Robustheit (+ destruktiv ungeschützt) | 5/5/3 | 0 / 1a / 6 |
+| H | Security & Shell-Safety | 5/4/3 | 4 (Guards: 0) |
+| I | Docs / README / CI-Drift | 5/6/3 | 7 (security.yml: 0) |
+| J | Dead-Code & Refactor-Reste | 0/1/8 | 8 (laufend) |
+| K | Tests | 3/4/2 | 0 / 7 |
+| L | Ansible-Modul-Qualität | 4/4/2 | 5 (UFW: Quick-Win) |
+
+**Gesamt: 27 High / 36 Medium / 25 Low = 88 Befunde.**


### PR DESCRIPTION
## Was

Rewrite-Plan: SOT → **natives Java-CLI** (Java 21 · Quarkus 3.37+ · Picocli · GraalVM/Mandrel), **Gradle + Justfile**, ausgeliefert als **Nix-Flake**. **Kein Produktivcode geändert** — nur Plandokumente unter `docs/`. Grundlage: mehrere Multi-Agenten-Design-Läufe + Context7-Verifikation (Quarkus/Picocli/Nix/NixOS-WSL). Funktionale Spec = 88 Ist-Befunde.

## Vier Säulen

1. **Dynamischer App-Manager** — CLI-App-Selektor, eigene Apps installieren/updaten über alle Apps hinweg, mit **Update-Überwachung** (`sot app outdated`). Apps = `app.yml`-Manifeste aus konfigurierbarem Katalog → neue App = Manifest, **kein Rebuild**.
2. **100 % Nix** — die CLI installiert Nix und zieht **alle** Deps + Apps über Nix (kein apt/brew). `NixService`, reproduzierbare Toolchain-Flake (pinned nixpkgs + `flake.lock`), `NixToolchainReconciler` ersetzt `DependencyInstaller`. `AppSourceType`: NIX/NIX_FLAKE.
3. **Cross-Platform** — Linux + macOS **first-class nativ**; Windows via **WSL2/NixOS-WSL** + `sot.exe`-Shim.
4. **Ein Bootstrap-Befehl pro Plattform** — von deiner Domain `/cli/`:
   - Linux/macOS: `curl -fsSL https://<host>/cli/install.sh | bash`
   - Windows: `irm https://<host>/cli/install.ps1 | iex`

## Delivery-Kniff

SOT selbst = **Nix-Flake**; `install.sh` installiert Nix (Determinate) → `nix profile install github:NiklasJavier/SOT` (Prebuilt aus **Binary-Cache**, kein Compile); Self-Update = `nix profile upgrade sot`. Flake = fetchurl-Wrapper ums CI-native-Binary (4 Systeme).

## Dateien

- [`docs/java-quarkus-rewrite-plan.md`](docs/java-quarkus-rewrite-plan.md) — der Plan (App-Manager · Nix-Substrat · Cross-Platform-Delivery · Windows/WSL · Architektur · 12 Phasen · Entscheidungen · Risiken).
- [`docs/java-quarkus-nix-substrate-brief.md`](docs/java-quarkus-nix-substrate-brief.md) · [`…-appmanager-brief.md`](docs/java-quarkus-appmanager-brief.md) · [`…-design-brief.md`](docs/java-quarkus-design-brief.md) — Design-Evidenz.
- [`docs/refactoring-findings.md`](docs/refactoring-findings.md) — 88-Befund-Spec.
- [`docs/refactoring-plan.md`](docs/refactoring-plan.md) — **superseded** (Bash-in-place).

## Load-bearing, bitte bestätigen

- **D5** Binary-Cache: **self-hosted attic auf deiner Domain** (empfohlen, souverän) vs. Cachix (zero-ops)?
- **D3** SOT-State-Root `/opt/sot` + dediziertes Nix-Toolchain-Profil?
- **D12** Windows-Linux-Env = **NixOS-WSL** + `sot.exe`-Shim?
- **D15** Gibt es produktive SOT-Installationen im Feld (→ `apt-deb→nix`/Legacy-Binary-Migration)?
- (D1 mostly-static glibc, D10 opentofu-Default: technisch gesetzt.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JPCrLEqgtMZoHW9kjvNCP