### PR TITLE
feat(hermes-peer-mcp): multi-lab protocol v1 — hardening + scenario harness + ops docs

### DIFF
--- a/docs/work/notes/multilab-AUDIT.md
+++ b/docs/work/notes/multilab-AUDIT.md
@@ -1,0 +1,60 @@
+# AUDIT — ErynoaGroup Multi-Lab OS (W0 reality lock)
+
+**Date:** 2026-07-09 · **Auditor:** Mython (Claude) · **Gate:** G0
+**Scope:** lab-alpha-0 / lab-beta-0 (ns `labs`), peer MCP :8755, skill `lab-peer-chat`,
+always-on AGENTS/SOUL, Agent Surface `ErynoaGroup/.ai-harness`, law `ErynoaGroup/.law`,
+host tests `SOT/tests/hermes_peer_mcp/`, gateway logs 13:53–19:12 (full retention, <6 h).
+**Method:** 5 parallel inventory agents + inline kubectl probes; hashes via sha256.
+
+---
+
+## 1. Artifact matrix
+
+| Artifact | α (lab-alpha-0) | β (lab-beta-0) | Surface (origin/main) | Drift? |
+|---|---|---|---|---|
+| `.env` telegram flags | require_mention=true · observe=true · allow_bots=all · exclusive_bot_mentions=true · free_response_chats=-5535276728 | same **minus** free_response | n/a (not in SSOT) | ✓ matches brief intent · ✗ not codified (D3) |
+| `config.yaml` telegram | mirrors .env; allow_from = Niklas+both bots | same | n/a | ✓ |
+| `config.yaml` mcp_servers | peer-beta → http://lab-beta:8755/mcp · peer-local → 127.0.0.1:8755 | peer-alpha/peer-local symmetric | n/a | ✓ (shared bearer token both entries) |
+| skill `lab-peer-chat` | SKILL.md `107b9387…` + references/{protocol,host-setup}.md + scripts | **identical hashes** | **identical after `git pull`** (was 2 behind) | ✓ parity; content defects D2/D3 |
+| always-on AGENTS.md/SOUL.md SSOT block | generated from `.law` `law/FULL.md` §275 | identical block | source: `ErynoaGroup/.law` | ✗ **D1 — wrong doctrine** |
+| SOUL persona | α „Ziel-Führer / Continuity-Anker" | β „Craft-Peer / Hands-on-Spezialist, gleichrangig, spricht bei @/Wake/tag_peer" | hand-written per lab (not in SSOT) | ✓ roles correct |
+| peer MCP code | server.py `7943da22…` peer_model `c5e02612…` | identical | n/a (untracked anywhere) | ✗ D4/D5 — host copy stale, no repo provenance |
+| peer MCP health | local ✓ · α→β ✓ | local ✓ · β→α ✓ | — | ✓ anti_swap=true both |
+| peer MCP launcher | manual `start-bg.sh`, root pid, no supervision | same | — | ✗ D6 |
+| host tests (SOT) | — | — | 11/11 green (unittest) | ✗ D4 (server.py differs), coverage gaps D7 |
+
+## 2. Drift register (owner file paths)
+
+| # | Drift | Owner / fix site | Workstream |
+|---|---|---|---|
+| **D1** | `.law` `law/FULL.md` §275 „Lab peer — **Telegram Group first**": claims bot→bot `@` wakes peer, mandates visible `PEER α→β:` badge lines, `ALLOW_BOTS=mentions`, MCP as fallback only. All four contradict live config + working bridge; block also self-contradicts SOUL Stil-Regel 4 (no badges). Generated into every lab's AGENTS.md+SOUL.md. | `ErynoaGroup/.law` → `law/FULL.md` (labs regenerate via R7 pull) | W2 |
+| **D2** | `references/protocol.md` is 16 lines: no actor table, no address truth table, no silence/leadership laws, no memory-continuity rule, no versioning. Wording „natural `@peer …`" invites the dead-end Telegram-@ pattern. | `.ai-harness` `skills/lab-peer-chat/references/protocol.md` | W1/W2 |
+| **D3** | `references/host-setup.md` shows only shared flags — missing the α/β split (`free_response_chats` α-only, no-free-response β) and `exclusive_bot_mentions`; no assertable checklist. | `.ai-harness` `skills/lab-peer-chat/references/host-setup.md` | W2/W3 |
+| **D4** | Host `SOT/tests/hermes_peer_mcp/server.py` (`713370f1…`) behind pods (`7943da22…`) — pods have newer `systemish` prompt in `ask_agent_group`. | SOT `tests/hermes_peer_mcp/server.py` (sync from pod, then harden) | W3 |
+| **D5** | Peer MCP code has no git home: pod files uid 501 (scp'd from workstation), two divergent launchers (`start.sh` vs `start-bg.sh`). | track in SOT + document deploy in host-setup | W3 + DEBT |
+| **D6** | No supervision: server.py = manually started root process; dies on pod restart. | `start-bg.sh` + DEBT (proper unit out of session scope) | W5/DEBT |
+| **D7** | `peer_model.py`: no `should_alpha_free_respond`; logging exists only as tool **return strings** (no stderr log lines); monotonic message-id check is a return-string warning invisible to monitoring; tests miss reply-to, explicit_mentions, both-mentioned, plain-text-negative rows. | SOT `tests/hermes_peer_mcp/` + pods | W3 |
+| **D8** | Doctrine `ALLOW_BOTS=mentions` vs live `all`. Telegram never delivers bot→bot group messages regardless, so the flag is inert for the peer path. Decision: **keep `all`**, codify in host-setup, delete the `mentions` claim (comes with D1). | `.law` + host-setup | W2 |
+| **D9** | Hermes security warning on β: skill outside trusted dir (`/root/.hermes/skills` symlink → `/persist/apps/ai-harness/...`). | lab install path | DEBT |
+| **D10** | Goal continuity: 3 synchronized session_reset pairs in window; α's „own the goal" has no durable store. | protocol §9 + W3 item 4 | W1/W3 |
+| **D11** | Ops churn: 24 gateway restarts/pod in 5.5 h; log retention < 6 h; two aborted `tag_peer` calls (interrupted by next user message). | risk register / observability | W5 |
+
+## 3. Chat-behavior evidence (group −5535276728, 15:57–19:12, 63 turn events)
+
+| Pattern | Count | Note |
+|---|---|---|
+| β answered unaddressed plain text | 1 (15:57) | first turn of window; clean afterwards (23 correct observe-only suppressions) |
+| Forbidden `α:`/`β:`/`Beta:` prefixes in outbound | ≥6 | lower bound (visible only via reply_to quotes) |
+| Peer wake attempted via Telegram `@` (dead end) | ≥3 | α×2, β×1 — never woke the peer; human relayed by hand |
+| Correct MCP `tag_peer` uses | 2 | **both interrupted** („user sent a new message", 148.8 s / 40.4 s) |
+| Too-long answers (small ask, ≥1.8 k chars) | 3 | incl. 2 057 chars for a 4-word follow-up |
+| Dropped/unanswered human messages | ~5 | 2 lost to restarts/stuck run |
+| session_reset pairs | 3 | 17:47 · 17:56 · 18:39 |
+
+Most violations date 16:00–17:45 — before the current SKILL.md generation landed. The live
+config intent itself is **correct**; the failures are doctrine (D1/D2) + runtime discipline (D7/D10).
+
+## 4. G0 verdict
+
+**PASS** — all drifts enumerated with owner paths. No blocker: cluster, Surface clone,
+`.law` clone, and host tests all reachable/verified. Proceed W1.

--- a/docs/work/notes/multilab-DEBT.md
+++ b/docs/work/notes/multilab-DEBT.md
@@ -1,0 +1,61 @@
+# DEBT — ErynoaGroup multi-lab elevation (2026-07-09)
+
+Open items this session could not close itself, with exact promotion paths.
+
+## D-A — Deploy hardened peer MCP to pods *(blocked: session permission — live pod file writes)*
+
+Host copy in `tests/hermes_peer_mcp/` is the hardened source (27/27 tests
+green; adds `should_alpha_free_respond`, structured `[peer-mcp] event=` logs,
+`monotonic_warning` as countable warn, `protocol` field in `/v1/health`).
+Pods still run the pre-hardening build (identical baseline, hash `7943da22…`).
+
+```bash
+cd tests/hermes_peer_mcp && ./deploy_to_labs.sh
+```
+
+## D-B — Live S4/S5 round-trips *(blocked: session permission — posts to real group)*
+
+```bash
+cd tests/hermes_peer_mcp && RUN_LIVE=1 ./run_scenarios.sh   # posts 2× "online?" + pongs
+```
+
+S6 + all config asserts already ran green (12/12) without posting.
+
+## D-C — Merge doctrine PRs, then labs pull + regenerate
+
+Branches: `.ai-harness` `lab-peer-protocol-v1` · `.law` `lab-peer-mcp-first`.
+After merge, on each lab (R7 pull path):
+
+```bash
+# in the lab's clones
+git -C /persist/apps/law pull --ff-only
+git -C /persist/apps/ai-harness pull --ff-only
+# regenerate always-on homes from law (surface install path on the lab)
+cd /persist/apps/ai-harness && just always-on   # or full: just install
+```
+
+Until then the labs' AGENTS.md/SOUL.md still carry the old „Telegram Group
+first" block (acceptance #7 pending merge).
+
+## D-D — Peer MCP has no canonical repo home
+
+Pod files were scp'd (uid 501, no git). Interim: SOT `tests/hermes_peer_mcp/`
+is the tracked source of truth. Proper home per R0: an `ErynoaGroup` app repo
+(candidate: `ErynoaGroup/hermes-peer-mcp`) with erynoa.md + gate + deploy.
+
+## D-E — No supervision for server.py
+
+Manual `start-bg.sh`, dies with pod restart, two divergent launchers
+(`start.sh` vs `start-bg.sh`). Decide one launcher + supervision (k8s sidecar
+container or chroot-systemd) — see ELEVATION P0/P1.
+
+## D-F — Hermes trust warning (β)
+
+`lab-peer-chat` skill symlink target outside trusted skills dir triggers a
+repeated gateway security warning. Either add `/persist/apps/ai-harness/skills`
+to Hermes' trusted roots or install skills as copies on labs.
+
+## D-G — `.law` CHANGELOG not extended
+
+`law/FULL.md` lab-peer block replaced on branch; `CHANGELOG.md` entry left to
+the PR review to avoid inventing a version scheme mid-session.

--- a/docs/work/notes/multilab-ELEVATION.md
+++ b/docs/work/notes/multilab-ELEVATION.md
@@ -1,0 +1,89 @@
+# ELEVATION — ErynoaGroup multi-lab OS (decisions + 48h backlog)
+
+**Date:** 2026-07-09 · **Gate:** G5 · Decisions below are chosen, not options.
+Evidence base: [multilab-AUDIT.md](./multilab-AUDIT.md) · protocol v1 in
+`.ai-harness` `skills/lab-peer-chat/references/protocol.md`.
+
+## 1. Latency budget — alpha free-response (decision)
+
+Measured today: small talk 3.6–75 s, worst turn 782 s (13 api_calls for 247
+chars), pings ~1 s via fast path.
+
+| Context | Budget (p50 / p95) | Mechanism |
+|---|---|---|
+| Group small talk / ack | 5 s / 15 s | depth policy §8 L2 (≤2 sentences ⇒ few tokens) |
+| Group substantive | 20 s / 60 s | cap group runs: `HERMES_MAX_ITERATIONS≈6` for the gateway session; long jobs → 1-sentence ack, work in background, report when done |
+| Peer wake (llm path) | 15 s / 45 s | `PEER_ASK_TIMEOUT=45`, `PEER_ASK_MAX_ITER=2` (already live) |
+| Ping | 1 s | `is_fast_ping` fast path (already live) |
+
+Tool-loops in group turns (782 s case: `skill_manage` retry loop) are the #1
+latency killer — the same_tool_failure_halt did fire; budget assumes it stays.
+
+## 2. γ onboarding template (decision: address-only joiner)
+
+Protocol §11.3 governs. Concretely for a new lab `gamma`:
+
+1. **Identity:** create `@erynoa_gamma_hermes_bot`, record bot id.
+2. **Code:** extend `peer_model.py` `_PEER_DEFAULTS` + `_ALIASES` with gamma.
+   ⚠ today's map is **pairwise** (one `remote_*` per lab) — multi-peer needs
+   the P1 refactor below before a 3rd lab actually joins.
+3. **Host profile** (address-only — γ is never leader):
+   `TELEGRAM_REQUIRE_MENTION=true`, `TELEGRAM_EXCLUSIVE_BOT_MENTIONS=true`,
+   `TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES=true`, **no**
+   `TELEGRAM_FREE_RESPONSE_CHATS`; `allow_from` += gamma id on α/β (and vice
+   versa); `mcp_servers` += `peer-gamma` on α/β, γ gets `peer-alpha`/`peer-beta`.
+4. **Doctrine:** SOUL persona file; always-on comes from `.law` unchanged;
+   `specialist.md` applies as-is.
+5. **Verify:** health identity, S6 guard, then live pings.
+
+## 3. Observability (decision: log-derived counters first, no new stack)
+
+One dashboard (start as a `just`/cron script emitting a table, not Grafana):
+
+| Metric | Source |
+|---|---|
+| messages/min + chars/turn per bot | gateway.log `response ready` lines |
+| peer wake latency | `[peer-mcp] event=wake` → `event=post` delta (post-deploy) |
+| exclusive drops | gateway.log exclusive/observed lines |
+| session_resets + gateway restarts | gateway.log banners (24 restarts/5.5 h today!) |
+| monotonic warns / rejects | `[peer-mcp] event=warn|reject` counts |
+
+Ship as `P2` script `tests/hermes_peer_mcp/peer_metrics.sh`; revisit a real
+exporter only if the labs outgrow log-grep.
+
+## 4. Risk register
+
+| Risk | Likelihood | Mitigation (state) |
+|---|---|---|
+| Alpha double-speak (summarizes/impersonates β) | med | protocol §8 L3/L4 + S-α2; guards block posting *as* β (live). Monitor via S-α2 log review |
+| Goal loss on session_reset | high (3 pairs/day) | §9 memory convention (doctrine landed; behavior check = P0 below) |
+| Surface/doctrine drift labs vs SSOT | med | R7 pull + STALE flags; drift is detectable lab-side only — D-C debt |
+| Token/latency cost of free-response | med | depth policy L2 + budget §1; watch chars/turn metric |
+| Peer MCP process dies (no supervision) | **high** | D-E debt — P0 below |
+| Gateway restart churn (24/5.5 h) | high | P1 investigation below |
+| Log retention < 6 h kills forensics | med | P1 logrotate/persist below |
+
+## 5. Next-48h backlog (any agent: Grok or Claude)
+
+**P0**
+1. Run `deploy_to_labs.sh` + `RUN_LIVE=1 run_scenarios.sh` (D-A/D-B, human-gated).
+2. Merge `.ai-harness#lab-peer-protocol-v1` + `.law#lab-peer-mcp-first`; labs
+   pull + `just always-on` (D-C) → acceptance #7 closes.
+3. Supervision for peer MCP: pick **one** launcher (`start-bg.sh`), add a
+   liveness loop (k8s-side restart or cron `pgrep || start-bg.sh`) (D-E).
+4. Verify alpha actually writes `## GROUP GOAL` memory on goal change (§9) —
+   one live probe after next reset.
+
+**P1**
+5. Multi-peer refactor of `peer_model.py` (peer *set*, not pairwise remote) —
+   prerequisite for γ; keep the same guard functions.
+6. Investigate gateway restart churn (24/pod/5.5 h) — config-reload loop vs
+   crash; fix or document.
+7. Gateway log rotation → persist 7 days (`/persist/rootfs/root/.hermes/logs/`).
+8. Group-turn iteration cap for alpha (latency budget §1 knob).
+9. Hermes trusted-skills root for `/persist/apps/ai-harness/skills` (D-F).
+
+**P2**
+10. `peer_metrics.sh` counters table (§3).
+11. Migrate peer MCP into `ErynoaGroup/hermes-peer-mcp` app repo (D-D, R0).
+12. S1/S2 semi-automation: scripted human-message prompts + log assertions.

--- a/tests/hermes_peer_mcp/deploy_to_labs.sh
+++ b/tests/hermes_peer_mcp/deploy_to_labs.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Deploy the hardened peer MCP (peer_model.py, server.py, tests) to both lab
+# pods, run the unit tests there, restart the server, verify health.
+# Run from tests/hermes_peer_mcp/. Requires kubectl access to ns "labs".
+set -euo pipefail
+
+NS="${NS:-labs}"
+DIR=/persist/apps/hermes-peer-mcp
+VENV_PY=/persist/rootfs/usr/local/lib/hermes-agent/venv/bin/python
+FILES=(peer_model.py server.py test_peer_mcp_model.py)
+
+for pod in lab-alpha-0 lab-beta-0; do
+  echo "== $pod: backup + copy =="
+  for f in "${FILES[@]}"; do
+    kubectl exec -n "$NS" "$pod" -c lab -- bash -c \
+      "cp $DIR/$f $DIR/$f.bak-\$(date +%Y%m%d) 2>/dev/null || true"
+    kubectl exec -i -n "$NS" "$pod" -c lab -- bash -c "cat > $DIR/$f" < "$f"
+  done
+
+  echo "== $pod: unit tests on pod =="
+  kubectl exec -n "$NS" "$pod" -c lab -- bash -c \
+    "cd $DIR && rm -rf __pycache__ && $VENV_PY -m unittest test_peer_mcp_model 2>&1 | tail -2"
+
+  echo "== $pod: restart peer MCP =="
+  kubectl exec -n "$NS" "$pod" -c lab -- bash -c \
+    "cd $DIR && kill \$(cat server.pid) 2>/dev/null || true; sleep 1; ./start-bg.sh; sleep 2"
+
+  echo "== $pod: health (expect protocol=1.0.0) =="
+  kubectl exec -n "$NS" "$pod" -c lab -- bash -c \
+    "chroot /persist/rootfs bash -lc 'python3 -c \"import urllib.request;print(urllib.request.urlopen(\\\"http://127.0.0.1:8755/v1/health\\\",timeout=5).read().decode())\"'"
+done
+
+echo "== done. Now: RUN_LIVE=1 ./run_scenarios.sh for S4/S5 =="

--- a/tests/hermes_peer_mcp/peer_model.py
+++ b/tests/hermes_peer_mcp/peer_model.py
@@ -1,0 +1,314 @@
+"""Pure peer chat model: address detection, natural shapes, identity invariants."""
+from __future__ import annotations
+
+import os
+import re
+from typing import Iterable
+
+# Operating Protocol version this model implements
+# (skills/lab-peer-chat/references/protocol.md in ErynoaGroup/.ai-harness).
+PROTOCOL_VERSION = "1.0.0"
+
+HOME_CHAT_ID = "-5535276728"
+
+_PEER_DEFAULTS: dict[str, dict[str, str]] = {
+    "alpha": {
+        "mark": "α",
+        "name": "alpha",
+        "bot": "erynoa_alpha_hermes_bot",
+        "bot_id": "8817307555",
+        "remote_url": "http://lab-beta:8755",
+        "remote_id": "beta",
+        "remote_mark": "β",
+        "remote_name": "beta",
+        "remote_bot": "erynoa_beta_hermes_bot",
+        "remote_bot_id": "8734599900",
+    },
+    "beta": {
+        "mark": "β",
+        "name": "beta",
+        "bot": "erynoa_beta_hermes_bot",
+        "bot_id": "8734599900",
+        "remote_url": "http://lab-alpha:8755",
+        "remote_id": "alpha",
+        "remote_mark": "α",
+        "remote_name": "alpha",
+        "remote_bot": "erynoa_alpha_hermes_bot",
+        "remote_bot_id": "8817307555",
+    },
+}
+
+PEER_MAP = _PEER_DEFAULTS
+
+_ALIASES: dict[str, tuple[str, ...]] = {
+    "alpha": (
+        "alpha", "alfa", "α",
+        "erynoa_alpha_hermes_bot", "@erynoa_alpha_hermes_bot",
+    ),
+    "beta": (
+        "beta", "berta", "β",
+        "erynoa_beta_hermes_bot", "@erynoa_beta_hermes_bot",
+    ),
+}
+
+
+def resolve_me(host_id: str, remote_url_override: str | None = None) -> dict[str, str]:
+    host_id = (host_id or "").strip().lower()
+    base = dict(
+        _PEER_DEFAULTS.get(
+            host_id,
+            {
+                "mark": (host_id[:1] or "?"),
+                "name": host_id or "lab",
+                "bot": f"erynoa_{host_id}_hermes_bot",
+                "bot_id": "",
+                "remote_url": "",
+                "remote_id": "peer",
+                "remote_mark": "?",
+                "remote_name": "peer",
+                "remote_bot": "",
+                "remote_bot_id": "",
+            },
+        )
+    )
+    if remote_url_override is not None:
+        override = remote_url_override.strip()
+    else:
+        running = (os.environ.get("LAB_ID") or os.environ.get("PEER_MCP_HOST_ID") or "").strip().lower()
+        override = os.environ.get("PEER_REMOTE_URL", "").strip() if running == host_id else ""
+    if override:
+        base["remote_url"] = override
+    return base
+
+
+def assert_peer_pair(host_id: str, remote_id: str) -> str | None:
+    """Return error if host/remote pair is invalid or swapped."""
+    h = (host_id or "").strip().lower()
+    r = (remote_id or "").strip().lower()
+    if not h or h not in _PEER_DEFAULTS:
+        return f"error: unknown host lab_id={host_id!r}"
+    if not r or r not in _PEER_DEFAULTS:
+        return f"error: unknown remote lab_id={remote_id!r}"
+    if h == r:
+        return f"error: host and remote must differ (got {h})"
+    expected = _PEER_DEFAULTS[h]["remote_id"]
+    if r != expected:
+        return f"error: lab {h} must talk to {expected}, not {r}"
+    # reverse must point back
+    if _PEER_DEFAULTS[r]["remote_id"] != h:
+        return f"error: peer map not symmetric for {h}<->{r}"
+    return None
+
+
+def assert_bot_matches_lab(lab_id: str, telegram_username: str) -> str | None:
+    """Return error if Telegram getMe username is not this lab's bot."""
+    lab = (lab_id or "").strip().lower()
+    uname = (telegram_username or "").strip().lstrip("@").lower()
+    if lab not in _PEER_DEFAULTS:
+        return f"error: unknown lab {lab_id!r}"
+    expected = _PEER_DEFAULTS[lab]["bot"].lower()
+    if uname != expected:
+        return (
+            f"error: identity mismatch — lab={lab} must post as @{expected}, "
+            f"token is @{uname or '?'} (refusing post to prevent swapped answers)"
+        )
+    return None
+
+
+def assert_remote_health(host_id: str, remote_health_lab_id: str) -> str | None:
+    """Remote /v1/health lab_id must be the expected peer, never self."""
+    h = (host_id or "").strip().lower()
+    rid = (remote_health_lab_id or "").strip().lower()
+    if not rid:
+        return "error: remote health missing lab_id"
+    if rid == h:
+        return f"error: remote URL points to self ({h}) — would swap speakers"
+    err = assert_peer_pair(h, rid)
+    if err:
+        return err
+    return None
+
+
+def _norm(text: str) -> str:
+    return " ".join(str(text or "").lower().split())
+
+
+def _contains_token(text_norm: str, token: str) -> bool:
+    t = token.lower().lstrip("@")
+    if not t:
+        return False
+    if t.startswith("erynoa_") or "bot" in t:
+        return t in text_norm or f"@{t}" in text_norm
+    return re.search(rf"(?<!\w){re.escape(t)}(?!\w)", text_norm) is not None
+
+
+def is_addressed_to(
+    text: str,
+    lab_id: str,
+    *,
+    reply_to_is_self: bool = False,
+    explicit_mentions: Iterable[str] | None = None,
+) -> bool:
+    lab = (lab_id or "").strip().lower()
+    if not lab:
+        return False
+    if reply_to_is_self:
+        return True
+    aliases = _ALIASES.get(lab, (lab, f"erynoa_{lab}_hermes_bot"))
+    text_n = _norm(text)
+    for a in aliases:
+        if _contains_token(text_n, a):
+            return True
+    if explicit_mentions:
+        me_bot = resolve_me(lab).get("bot", "").lower()
+        for m in explicit_mentions:
+            ml = str(m).lower().lstrip("@")
+            if ml == me_bot or ml == lab:
+                return True
+    return False
+
+
+def is_addressed_to_peer(text: str, lab_id: str) -> bool:
+    me = resolve_me(lab_id)
+    peer = me.get("remote_id") or ""
+    return is_addressed_to(text, peer)
+
+
+def _bot_handles(mentions: Iterable[str] | None) -> set[str]:
+    out: set[str] = set()
+    for m in mentions or ():
+        h = str(m).strip().lstrip("@").lower()
+        if h.startswith("erynoa_") and h.endswith("_hermes_bot"):
+            out.add(h)
+    return out
+
+
+def should_alpha_free_respond(
+    text: str,
+    mentions: Iterable[str] | None = None,
+    *,
+    reply_to_bot: str | None = None,
+    chat_id: str = HOME_CHAT_ID,
+    free_response_chats: Iterable[str] = (HOME_CHAT_ID,),
+    author_is_human: bool = True,
+    lab_id: str = "alpha",
+) -> bool:
+    """Protocol §4: the leader free-responds iff the chat is a free-response
+    chat, the author is human, the turn is not exclusively another bot's
+    mention (T3) and not a reply to another bot (T6).
+
+    Deliberately ignores names in `text`: prose never addresses a bot —
+    only Telegram entities (mentions / reply-to) do (protocol §3).
+    """
+    if not author_is_human:
+        return False
+    if str(chat_id) not in {str(c) for c in free_response_chats}:
+        return False
+    me_bot = resolve_me(lab_id).get("bot", "").lower()
+    if reply_to_bot:
+        rb = str(reply_to_bot).strip().lstrip("@").lower()
+        if rb and rb != me_bot:
+            return False  # T6 — that turn belongs to the replied-to bot
+    bots = _bot_handles(mentions)
+    if bots and me_bot not in bots:
+        return False  # T3 — exclusively other bot(s) mentioned
+    return True
+
+
+def parse_message_id(post_result: str) -> int | None:
+    """Extract message_id from a `_telegram_post` result line."""
+    if "message_id=" not in (post_result or ""):
+        return None
+    try:
+        return int(post_result.split("message_id=")[1].split()[0].strip())
+    except Exception:
+        return None
+
+
+def monotonic_warning(self_mid: int | None, peer_mid: int | None) -> str | None:
+    """Peer's reply must be posted after the caller's line (protocol §6)."""
+    if self_mid and peer_mid and peer_mid <= self_mid:
+        return f"warning: peer_message_id={peer_mid} <= self_message_id={self_mid}"
+    return None
+
+
+def clean_chat_text(text: str, max_len: int = 900) -> str:
+    """Strip machine/lab labels so group text looks like a normal chat message."""
+    s = str(text or "").strip()
+    # drop PEER frames first
+    s = re.sub(r"\bPEER\s+[αβa-zA-Z?]+\s*→\s*[αβa-zA-Z?]+\s*:\s*", "", s, flags=re.I)
+    s = re.sub(r"\bPEER\s+[αβa-zA-Z?]+\s*->\s*[αβa-zA-Z?]+\s*:\s*", "", s, flags=re.I)
+    # drop @bot handles (display name is already the Telegram sender)
+    s = re.sub(r"@?erynoa_\w+_hermes_bot\b\s*", "", s, flags=re.I)
+    # drop leading lab marks / name labels: "α:", "β:", "alpha:", "Beta —", "[alpha]", etc.
+    for _ in range(3):  # nested junk
+        s2 = re.sub(
+            r"^(?:[αβ]|alpha|beta|alfa|berta)\s*[:：\-—–|]\s*",
+            "",
+            s,
+            flags=re.I,
+        )
+        s2 = re.sub(r"^\[(?:alpha|beta|α|β)\]\s*", "", s2, flags=re.I)
+        s2 = re.sub(r"^(?:lab\s+)?(?:alpha|beta)\s+", "", s2, flags=re.I)
+        if s2 == s:
+            break
+        s = s2.strip()
+    s = " ".join(s.split())
+    if len(s) > max_len:
+        s = s[: max_len - 1] + "…"
+    return s
+
+
+def format_chat_outbound(ask: str, *, peer_bot: str, peer_name: str) -> str:
+    body = clean_chat_text(ask, max_len=700)
+    if not body:
+        body = "…"
+    pb = (peer_bot or "").lstrip("@")
+    if pb and f"@{pb}".lower() not in body.lower():
+        return f"@{pb} {body}"
+    return body
+
+
+def format_chat_reply(reply: str) -> str:
+    """Final text posted to Telegram — plain chat, no lab badges."""
+    body = clean_chat_text(reply, max_len=1200)
+    for bad in ("skill_view", "mcp__", "Reading skill", "ask_agent", "PEER "):
+        if bad in body:
+            body = "\n".join(ln for ln in body.splitlines() if bad not in ln).strip()
+    # never allow starting with greek/lab mark after clean
+    body = re.sub(r"^[αβ]\s*", "", body)
+    return body or "…"
+
+
+def is_fast_ping(ask: str) -> bool:
+    s = clean_chat_text(ask).lower().strip(" ?.!")
+    pings = {
+        "ping", "pong", "online", "online?", "da", "da?", "hi", "hey", "hallo",
+        "hello", "status", "up", "alive", "ack", "ok", "hier", "hier?",
+        "bist du da", "bist du online", "noch da", "melder", "melde dich",
+    }
+    if s in pings:
+        return True
+    if len(s) <= 24 and any(s.startswith(p) for p in ("ping", "online", "da?", "hi ", "hey")):
+        return True
+    return False
+
+
+def fast_pong_text(lab_id: str) -> str:
+    # Natural chat — no alpha/beta label; Telegram already shows who spoke
+    return "Ja, bin online."
+
+
+def format_peer_ask_line(ask: str, *, mark: str, remote_mark: str, remote_bot: str) -> str:
+    peer_name = "beta" if "beta" in (remote_bot or "") else "alpha"
+    return format_chat_outbound(ask, peer_bot=remote_bot, peer_name=peer_name)
+
+
+def format_peer_reply_line(reply: str, *, mark: str, address_bot: str = "") -> str:
+    return format_chat_reply(reply)
+
+
+def validate_nonempty(value: str, label: str = "text") -> str | None:
+    if not value or not str(value).strip():
+        return f"error: empty {label}"
+    return None

--- a/tests/hermes_peer_mcp/run_scenarios.sh
+++ b/tests/hermes_peer_mcp/run_scenarios.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Scenario harness — ErynoaGroup multi-lab OS (protocol v1). See scenarios.md.
+# Default: config asserts + S6 guard (no group posts).
+# RUN_LIVE=1: adds S4/S5 tag_peer round-trips — POSTS REAL MESSAGES to ErynoaGroup.
+set -uo pipefail
+
+NS="${NS:-labs}"
+PASS=0 FAIL=0
+
+chk() { # name want got
+  if [[ "$3" == "$2" ]]; then echo "PASS $1"; ((PASS++)); else echo "FAIL $1  want=[$2] got=[$3]"; ((FAIL++)); fi
+}
+chk_contains() { # name needle haystack
+  if [[ "$3" == *"$2"* ]]; then echo "PASS $1"; ((PASS++)); else echo "FAIL $1  missing=[$2]"; ((FAIL++)); fi
+}
+chk_absent() { # name needle haystack
+  if [[ "$3" != *"$2"* ]]; then echo "PASS $1"; ((PASS++)); else echo "FAIL $1  forbidden=[$2] present"; ((FAIL++)); fi
+}
+
+pod_env_grep() { # pod pattern -> count
+  kubectl exec -n "$NS" "$1" -c lab -- bash -c \
+    "chroot /persist/rootfs bash -lc 'grep -cE \"$2\" /root/.hermes/.env'" 2>/dev/null | tr -d '[:space:]'
+}
+
+pod_py() { # pod python-src (runs inside chroot with peer MCP env sourced)
+  kubectl exec -i -n "$NS" "$1" -c lab -- bash -c \
+    "chroot /persist/rootfs bash -lc 'set -a; source /persist/apps/hermes-peer-mcp/env; set +a; python3 -'" <<< "$2" 2>/dev/null
+}
+
+post_json() { # pod url json-payload -> "HTTP_CODE|body"
+  pod_py "$1" "
+import json, os, urllib.request, urllib.error
+req = urllib.request.Request(
+    '$2', data=json.dumps($3).encode(),
+    headers={'Content-Type': 'application/json',
+             'Authorization': 'Bearer ' + os.environ['PEER_MCP_TOKEN']},
+    method='POST')
+try:
+    with urllib.request.urlopen(req, timeout=120) as r:
+        print(str(r.status) + '|' + r.read().decode())
+except urllib.error.HTTPError as e:
+    print(str(e.code) + '|' + (e.read().decode() if e.fp else ''))
+"
+}
+
+get_health() { # pod url -> body
+  pod_py "$1" "
+import os, urllib.request
+req = urllib.request.Request('$2', headers={'Authorization': 'Bearer ' + os.environ['PEER_MCP_TOKEN']})
+print(urllib.request.urlopen(req, timeout=10).read().decode())
+"
+}
+
+echo "== A: config asserts =="
+chk A1-alpha-free-response 1 "$(pod_env_grep lab-alpha-0 '^TELEGRAM_FREE_RESPONSE_CHATS=-5535276728$')"
+chk A2-beta-no-free-response 0 "$(pod_env_grep lab-beta-0 '^TELEGRAM_FREE_RESPONSE_CHATS')"
+chk A3-alpha-mention-gates 2 "$(pod_env_grep lab-alpha-0 '^TELEGRAM_(REQUIRE_MENTION|EXCLUSIVE_BOT_MENTIONS)=true$')"
+chk A3-beta-mention-gates 2 "$(pod_env_grep lab-beta-0 '^TELEGRAM_(REQUIRE_MENTION|EXCLUSIVE_BOT_MENTIONS)=true$')"
+
+echo "== A4: identity health =="
+ah="$(get_health lab-alpha-0 http://127.0.0.1:8755/v1/health)"
+bh="$(get_health lab-beta-0 http://127.0.0.1:8755/v1/health)"
+chk_contains A4-alpha-id '"lab_id":"alpha"' "$ah"
+chk_contains A4-alpha-remote '"remote":"beta"' "$ah"
+chk_contains A4-alpha-antiswap '"anti_swap":true' "$ah"
+chk_contains A4-beta-id '"lab_id":"beta"' "$bh"
+chk_contains A4-beta-remote '"remote":"alpha"' "$bh"
+chk_contains A4-beta-antiswap '"anti_swap":true' "$bh"
+
+echo "== S6: wrong expect_lab -> 409, no post =="
+r6a="$(post_json lab-alpha-0 http://127.0.0.1:8755/v1/ask_group '{"prompt":"scenario S6 guard check","expect_lab":"beta"}')"
+chk S6-alpha-409 409 "${r6a%%|*}"
+r6b="$(post_json lab-beta-0 http://127.0.0.1:8755/v1/ask_group '{"prompt":"scenario S6 guard check","expect_lab":"alpha"}')"
+chk S6-beta-409 409 "${r6b%%|*}"
+
+if [[ "${RUN_LIVE:-0}" == "1" ]]; then
+  echo "== S4: tag_peer alpha -> beta (LIVE group post) =="
+  r4="$(post_json lab-alpha-0 http://127.0.0.1:8755/v1/tag_peer '{"ask":"online?"}')"
+  b4="${r4#*|}"
+  chk S4-http-200 200 "${r4%%|*}"
+  chk_contains S4-as-alpha 'as=alpha' "$b4"
+  chk_contains S4-peer-as-beta 'as=beta' "$b4"
+  chk_contains S4-self-posted 'message_id=' "$b4"
+  chk_absent S4-no-alpha-badge '\\u03b1:' "$b4"
+  chk_absent S4-no-beta-badge '\\u03b2:' "$b4"
+
+  echo "== S5: tag_peer beta -> alpha (LIVE group post) =="
+  r5="$(post_json lab-beta-0 http://127.0.0.1:8755/v1/tag_peer '{"ask":"online?"}')"
+  b5="${r5#*|}"
+  chk S5-http-200 200 "${r5%%|*}"
+  chk_contains S5-as-beta 'as=beta' "$b5"
+  chk_contains S5-peer-as-alpha 'as=alpha' "$b5"
+  chk_contains S5-self-posted 'message_id=' "$b5"
+  chk_absent S5-no-alpha-badge '\\u03b1:' "$b5"
+  chk_absent S5-no-beta-badge '\\u03b2:' "$b5"
+else
+  echo "== S4/S5 skipped (set RUN_LIVE=1 to post real group messages) =="
+fi
+
+echo
+echo "== result: PASS=$PASS FAIL=$FAIL =="
+[[ "$FAIL" == "0" ]]

--- a/tests/hermes_peer_mcp/scenarios.md
+++ b/tests/hermes_peer_mcp/scenarios.md
@@ -1,0 +1,49 @@
+# Scenario suite — ErynoaGroup multi-lab OS (protocol v1)
+
+Executable evidence for the address calculus (protocol §3) and the peer
+bridge (§6). Runner: [`run_scenarios.sh`](./run_scenarios.sh).
+
+| Mode | What runs |
+|---|---|
+| `./run_scenarios.sh` | config asserts A1–A4 + guard scenario S6 (no group posts) |
+| `RUN_LIVE=1 ./run_scenarios.sh` | additionally S4 + S5 — **posts real messages** to ErynoaGroup |
+
+## Scenarios
+
+| ID | Action | Expect | Automation |
+|----|--------|--------|------------|
+| S1 | Human plain „wie geht's" | α answers; β observe-only | **log grep** (below) — human input can't be automated |
+| S2 | Human exclusive `@erynoa_beta_hermes_bot` | α silent (drop in log); β answers | **log grep** (below) |
+| S3 | Human „frag beta online" (no @) | α answers + `tag_peer`; β posts plain pong | semi-manual: human sends text, then S4 mechanics apply |
+| S4 | `tag_peer` α→β („online?") | result `as=alpha`, peer part `as=beta`, both posted, no `α:`/`β:` in bodies | **automated** (`RUN_LIVE=1`) |
+| S5 | `tag_peer` β→α | symmetric | **automated** (`RUN_LIVE=1`) |
+| S6 | wake with wrong `expect_lab` | HTTP 409, **no post** | **automated** (default) |
+| S7 | identity swap (wrong bot token) | getMe reject before any post | **documented** — guard `_assert_local_bot_token` runs on every post; injecting a foreign token is not safely automatable |
+
+## Config asserts (always run)
+
+| ID | Assert | Enforces |
+|---|---|---|
+| A1 | α `.env` has exactly `TELEGRAM_FREE_RESPONSE_CHATS=-5535276728` | T1 leader |
+| A2 | β `.env` has **no** `TELEGRAM_FREE_RESPONSE_CHATS` | one leader only |
+| A3 | both: `REQUIRE_MENTION=true` + `EXCLUSIVE_BOT_MENTIONS=true` | T2/T3/T5/T6 |
+| A4 | `/v1/health` per pod: `lab_id` own, `remote` other, `anti_swap` true | §1 identity |
+
+## S1/S2 log-grep recipes (evidence, not automation)
+
+```bash
+# S1 — after a plain human message: alpha answered, beta only observed
+kubectl exec -n labs lab-alpha-0 -c lab -- \
+  grep -E 'inbound message:' /persist/rootfs/root/.hermes/logs/gateway.log | tail -3
+kubectl exec -n labs lab-beta-0 -c lab -- \
+  grep -E 'observed \(no bot' /persist/rootfs/root/.hermes/logs/gateway.log | tail -3
+
+# S2 — after a human message that ONLY @-mentions beta:
+# alpha log shows drop/observe (exclusive), beta log shows inbound + response
+kubectl exec -n labs lab-alpha-0 -c lab -- \
+  grep -E 'exclusive|observed \(no bot' /persist/rootfs/root/.hermes/logs/gateway.log | tail -3
+```
+
+Post-deploy (once the hardened `server.py` runs on the pods), the peer MCP
+additionally emits countable `[peer-mcp] event=` lines:
+`event=wake|post|reject|warn` with `as= target= path=fast|llm self_mid= peer_mid=`.

--- a/tests/hermes_peer_mcp/server.py
+++ b/tests/hermes_peer_mcp/server.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Peer Hermes MCP — natural group chat with hard anti-swap identity guards.
+
+Rule: every Telegram post is checked against getMe vs expected bot for HOST_ID.
+Every remote wake is checked: remote health lab_id must be expected peer, never self.
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from peer_model import (
+    PROTOCOL_VERSION,
+    assert_bot_matches_lab,
+    assert_peer_pair,
+    assert_remote_health,
+    clean_chat_text,
+    fast_pong_text,
+    format_chat_outbound,
+    format_chat_reply,
+    is_addressed_to,
+    is_fast_ping,
+    monotonic_warning,
+    parse_message_id,
+    resolve_me,
+    validate_nonempty,
+)
+
+_VENV_SITE = "/usr/local/lib/hermes-agent/venv/lib/python3.11/site-packages"
+if _VENV_SITE not in sys.path and os.path.isdir(_VENV_SITE):
+    sys.path.insert(0, _VENV_SITE)
+
+from mcp.server.fastmcp import FastMCP
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+HOST_ID = (os.environ.get("LAB_ID") or os.environ.get("PEER_MCP_HOST_ID") or socket.gethostname()).strip().lower()
+PORT = int(os.environ.get("PEER_MCP_PORT", "8755"))
+TOKEN = os.environ.get("PEER_MCP_TOKEN", "").strip()
+HERMES_BIN = os.environ.get("HERMES_BIN", "hermes")
+PEER_ASK_MODEL = os.environ.get("PEER_ASK_MODEL", "grok-4.5")
+PEER_ASK_TIMEOUT = int(os.environ.get("PEER_ASK_TIMEOUT", "45"))
+PEER_ASK_MAX_ITER = os.environ.get("PEER_ASK_MAX_ITER", "2")
+
+ME = resolve_me(HOST_ID)
+SELF_BOT = ME.get("bot", "")
+SELF_NAME = ME.get("name", HOST_ID)
+SELF_BOT_ID = ME.get("bot_id", "")
+REMOTE_URL = (ME.get("remote_url") or "").rstrip("/")
+REMOTE_ID = ME.get("remote_id") or ""
+REMOTE_BOT = ME.get("remote_bot") or ""
+REMOTE_NAME = ME.get("remote_name") or REMOTE_ID
+
+# Fail fast at import if map is inconsistent
+_pair_err = assert_peer_pair(HOST_ID, REMOTE_ID) if REMOTE_ID else f"error: no remote for {HOST_ID}"
+if _pair_err:
+    print(f"[peer-hermes-mcp] FATAL map: {_pair_err}", file=sys.stderr)
+
+mcp = FastMCP(
+    f"peer-hermes-{HOST_ID}",
+    instructions=(
+        f"Lab '{HOST_ID}' (@{SELF_BOT}). Natural chat. Anti-swap identity guards on. "
+        f"Remote must be {REMOTE_ID}. tag_peer wakes peer only. Rule1: only answer if addressed."
+    ),
+    host="0.0.0.0",
+    port=PORT,
+)
+mcp.settings.host = "0.0.0.0"
+mcp.settings.port = PORT
+try:
+    mcp.settings.transport_security.enable_dns_rebinding_protection = False
+except Exception:
+    pass
+
+
+class BearerAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path in ("/health", "/v1/health"):
+            return await call_next(request)
+        if not TOKEN:
+            return await call_next(request)
+        auth = request.headers.get("authorization", "")
+        if auth.strip() != f"Bearer {TOKEN}":
+            return JSONResponse({"error": "unauthorized"}, status_code=401)
+        return await call_next(request)
+
+
+def _log(event: str, **fields: Any) -> None:
+    """One structured line per event to stderr — greppable, countable.
+
+    Vocabulary: event=wake|post|reject|warn|error · as=<lab> · target=<lab> ·
+    path=fast|llm · self_mid/peer_mid=<message_id>.
+    """
+    kv = " ".join(f"{k}={v}" for k, v in fields.items() if v is not None and v != "")
+    print(f"[peer-mcp] event={event} as={HOST_ID} {kv}".rstrip(), file=sys.stderr, flush=True)
+
+
+def _load_hermes_env() -> dict[str, str]:
+    out: dict[str, str] = {}
+    p = Path("/root/.hermes/.env")
+    if not p.exists():
+        return out
+    for line in p.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        out[k.strip()] = v.strip().strip('"').strip("'")
+    return out
+
+
+def _telegram_get_me(bot_token: str) -> dict[str, Any]:
+    req = urllib.request.Request(f"https://api.telegram.org/bot{bot_token}/getMe", method="GET")
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        data = json.loads(resp.read().decode())
+    if not data.get("ok"):
+        return {}
+    return data.get("result") or {}
+
+
+def _assert_local_bot_token(bot_token: str) -> str | None:
+    """Hard anti-swap: token must belong to THIS lab's bot only."""
+    try:
+        me = _telegram_get_me(bot_token)
+    except Exception as e:
+        return f"error: getMe failed: {e}"
+    uname = me.get("username") or ""
+    tid = str(me.get("id") or "")
+    err = assert_bot_matches_lab(HOST_ID, uname)
+    if err:
+        return err
+    if SELF_BOT_ID and tid and tid != SELF_BOT_ID:
+        return (
+            f"error: identity mismatch — lab={HOST_ID} expects bot_id={SELF_BOT_ID}, "
+            f"token is id={tid}"
+        )
+    return None
+
+
+def _telegram_post(text: str, reply_to_message_id: int | None = None) -> str:
+    env = _load_hermes_env()
+    bot = env.get("TELEGRAM_BOT_TOKEN") or os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    chat = (
+        env.get("TELEGRAM_HOME_CHANNEL")
+        or env.get("TELEGRAM_GROUP_ALLOWED_CHATS")
+        or os.environ.get("TELEGRAM_HOME_CHANNEL", "")
+    )
+    if "," in chat:
+        chat = chat.split(",")[0].strip()
+    if not bot or not chat or chat == "*":
+        return "error: missing TELEGRAM_BOT_TOKEN or TELEGRAM_HOME_CHANNEL"
+
+    id_err = _assert_local_bot_token(bot)
+    if id_err:
+        return id_err
+
+    if text.strip().startswith("@"):
+        body_text = " ".join(text.split())[:4000]
+    else:
+        body_text = format_chat_reply(text)[:4000]
+
+    payload: dict[str, Any] = {
+        "chat_id": chat,
+        "text": body_text,
+        "disable_web_page_preview": "true",
+    }
+    if reply_to_message_id:
+        payload["reply_to_message_id"] = str(int(reply_to_message_id))
+        payload["allow_sending_without_reply"] = "true"
+    data = urllib.parse.urlencode(payload).encode()
+    req = urllib.request.Request(
+        f"https://api.telegram.org/bot{bot}/sendMessage",
+        data=data,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            raw = json.loads(resp.read().decode())
+        if not raw.get("ok"):
+            return f"error: telegram {raw}"
+        result = raw.get("result") or {}
+        mid = result.get("message_id")
+        # Telegram also returns from.username — verify speaker again
+        from_u = ((result.get("from") or {}).get("username") or "").lower()
+        if from_u and from_u != SELF_BOT.lower():
+            return (
+                f"error: post speaker mismatch — expected @{SELF_BOT}, telegram from=@{from_u} "
+                f"message_id={mid}"
+            )
+        return f"posted chat={chat} message_id={mid} as={HOST_ID} bot=@{SELF_BOT}"
+    except Exception as e:
+        return f"error: telegram post failed: {e}"
+
+
+def _run_hermes(prompt: str) -> str:
+    env = {
+        **os.environ,
+        "HERMES_ACCEPT_HOOKS": "1",
+        "HERMES_MAX_ITERATIONS": PEER_ASK_MAX_ITER,
+        "HOME": os.environ.get("HOME", "/root"),
+    }
+    cmd = [
+        HERMES_BIN, "-z", str(prompt).strip(),
+        "--cli", "-m", PEER_ASK_MODEL,
+        "--ignore-rules", "--yolo",
+    ]
+    try:
+        out = subprocess.check_output(
+            cmd, text=True, timeout=PEER_ASK_TIMEOUT, stderr=subprocess.STDOUT, env=env,
+        )
+        return (out or "").strip() or "…"
+    except subprocess.TimeoutExpired:
+        return f"error: peer timed out after {PEER_ASK_TIMEOUT}s"
+    except subprocess.CalledProcessError as e:
+        return f"error (exit {e.returncode}):\n{(e.output or '')[:1500]}"
+    except Exception as e:
+        return f"error: {e}"
+
+
+def _http_json(url: str, payload: dict[str, Any] | None = None, timeout: int = 90, method: str = "POST") -> dict[str, Any]:
+    headers = {"Content-Type": "application/json"}
+    if TOKEN:
+        headers["Authorization"] = f"Bearer {TOKEN}"
+    data = None if payload is None or method == "GET" else json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode() if e.fp else ""
+        return {"error": f"HTTP {e.code}: {body[:400]}"}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def _verify_remote_or_error() -> str | None:
+    """Anti-swap: remote health must be expected peer lab."""
+    if not REMOTE_URL:
+        return "error: PEER_REMOTE_URL empty"
+    pair = assert_peer_pair(HOST_ID, REMOTE_ID)
+    if pair:
+        return pair
+    health = _http_json(f"{REMOTE_URL}/v1/health", payload=None, timeout=10, method="GET")
+    if "error" in health and "lab_id" not in health:
+        return f"error: remote health failed: {health.get('error')}"
+    rid = str(health.get("lab_id") or "")
+    return assert_remote_health(HOST_ID, rid)
+
+
+@mcp.tool()
+def peer_identity() -> str:
+    return (
+        f"lab_id={HOST_ID}\nname={SELF_NAME}\nbot=@{SELF_BOT}\nbot_id={SELF_BOT_ID}\n"
+        f"remote={REMOTE_ID}\nremote_bot=@{REMOTE_BOT}\nremote_url={REMOTE_URL}\n"
+        f"anti_swap=getMe+remote_health\nrule1=is_addressed_to"
+    )
+
+
+@mcp.tool()
+def peer_status() -> str:
+    return (
+        f"lab_id={HOST_ID}\nok=true\nremote={REMOTE_ID}\n"
+        f"ask_model={PEER_ASK_MODEL}\ntimeout={PEER_ASK_TIMEOUT}\n"
+        f"tools=tag_peer,ask_agent_group,group_say,am_i_addressed"
+    )
+
+
+@mcp.tool()
+def am_i_addressed(text: str, reply_to_is_self: bool = False) -> str:
+    hit = is_addressed_to(text, HOST_ID, reply_to_is_self=bool(reply_to_is_self))
+    return f"lab={HOST_ID}\naddressed={'yes' if hit else 'no'}\ntext={clean_chat_text(text)[:200]}"
+
+
+@mcp.tool()
+def ask_agent(prompt: str) -> str:
+    err = validate_nonempty(prompt, "prompt")
+    if err:
+        return err
+    return _run_hermes(str(prompt).strip())
+
+
+@mcp.tool()
+def group_say(text: str) -> str:
+    err = validate_nonempty(text, "text")
+    if err:
+        return err
+    return _telegram_post(format_chat_reply(text))
+
+
+@mcp.tool()
+def ask_agent_group(prompt: str, reply_to_message_id: int | None = None, from_lab: str | None = None) -> str:
+    """Answer in-group as THIS bot only (never posts as peer)."""
+    err = validate_nonempty(prompt, "prompt")
+    if err:
+        return err
+    # Reject self-wake / wrong initiator (anti-swap / loop)
+    if from_lab:
+        fl = str(from_lab).strip().lower()
+        if fl == HOST_ID:
+            _log("reject", reason="self_wake", from_lab=fl)
+            return f"error: refused self-wake from_lab={fl} host={HOST_ID}"
+        if fl and fl != REMOTE_ID:
+            _log("reject", reason="wrong_from_lab", from_lab=fl, expected=REMOTE_ID)
+            return f"error: refused wake from unexpected lab={fl} (expected peer={REMOTE_ID})"
+    ask = clean_chat_text(prompt)
+    t0 = time.time()
+
+    if is_fast_ping(ask):
+        reply = fast_pong_text(HOST_ID)
+        post = _telegram_post(reply, reply_to_message_id=reply_to_message_id)
+        _log(
+            "post", path="fast", from_lab=from_lab, reply_to=reply_to_message_id,
+            self_mid=parse_message_id(post), elapsed_s=f"{time.time()-t0:.1f}",
+        )
+        return (
+            f"as={HOST_ID}\nbot=@{SELF_BOT}\nreply={reply}\n{post}\n"
+            f"elapsed_s={time.time()-t0:.1f}\npath=fast_ping"
+        )
+
+    systemish = (
+        f"You are the Telegram bot {SELF_NAME} in group ErynoaGroup. "
+        f"Never claim to be {REMOTE_NAME}. You were addressed. "
+        f"Write like a normal chat message only: max 2 short sentences. "
+        f"Do NOT prefix with alpha/beta/α/β/lab marks. Do NOT use PEER frames. "
+        f"No tools, no meta, no signature.\n\nMessage:\n{ask}"
+    )
+    reply = _run_hermes(systemish)
+    elapsed = time.time() - t0
+    if reply.startswith("error"):
+        _log("error", path="llm", from_lab=from_lab, detail=reply.splitlines()[0][:120])
+        return f"as={HOST_ID}\n{reply}\nelapsed_s={elapsed:.1f}"
+    body = format_chat_reply(reply)
+    post = _telegram_post(body, reply_to_message_id=reply_to_message_id)
+    _log(
+        "post", path="llm", from_lab=from_lab, reply_to=reply_to_message_id,
+        self_mid=parse_message_id(post), chars=len(body), elapsed_s=f"{elapsed:.1f}",
+    )
+    return (
+        f"as={HOST_ID}\nbot=@{SELF_BOT}\nreply={body}\n{post}\n"
+        f"elapsed_s={elapsed:.1f}\npath=llm"
+    )
+
+
+@mcp.tool()
+def tag_peer(ask: str) -> str:
+    """Post as THIS bot, wake REMOTE peer only — never answers as the peer."""
+    err = validate_nonempty(ask, "ask")
+    if err:
+        return err
+    pair = assert_peer_pair(HOST_ID, REMOTE_ID)
+    if pair:
+        return pair
+    remote_err = _verify_remote_or_error()
+    if remote_err:
+        return remote_err
+
+    ask_s = clean_chat_text(ask)
+    line = format_chat_outbound(ask_s, peer_bot=REMOTE_BOT, peer_name=REMOTE_NAME)
+    # Must @ the REMOTE bot only
+    if REMOTE_BOT and f"@{REMOTE_BOT}" not in line and REMOTE_BOT not in line:
+        line = f"@{REMOTE_BOT} {line}"
+
+    post_self = _telegram_post(line)
+    if post_self.startswith("error"):
+        _log("error", reason="self_post_failed", target=REMOTE_ID)
+        return f"as={HOST_ID}\nself={post_self}"
+    mid = parse_message_id(post_self)
+    _log("wake", target=REMOTE_ID, self_mid=mid)
+
+    payload: dict[str, Any] = {
+        "prompt": ask_s,
+        "from_lab": HOST_ID,
+        "expect_lab": REMOTE_ID,
+    }
+    if mid:
+        payload["reply_to_message_id"] = mid
+
+    r = _http_json(
+        f"{REMOTE_URL}/v1/ask_group",
+        payload,
+        timeout=PEER_ASK_TIMEOUT + 25,
+    )
+    if "error" in r and "result" not in r:
+        return f"as={HOST_ID}\nself={post_self}\nerror: remote wake failed: {r.get('error')}"
+
+    peer_result = str(r.get("result") or r)
+    peer_lab = str(r.get("lab_id") or "")
+    if peer_result.startswith("error") or "error:" in peer_result.split("\n", 1)[0]:
+        return f"as={HOST_ID}\ntarget={REMOTE_ID}\nself={post_self}\npeer={peer_result}"
+    # Anti-swap: response must be from remote lab
+    if peer_lab and peer_lab != REMOTE_ID:
+        return (
+            f"as={HOST_ID}\nself={post_self}\n"
+            f"error: remote answered as lab_id={peer_lab} expected={REMOTE_ID} (swap blocked)\n"
+            f"peer_raw={peer_result[:300]}"
+        )
+    if f"as={HOST_ID}" in peer_result and f"as={REMOTE_ID}" not in peer_result:
+        # peer should tag itself as remote
+        if peer_result.startswith("as=") and f"as={REMOTE_ID}" not in peer_result.split("\n", 1)[0]:
+            return (
+                f"as={HOST_ID}\nself={post_self}\n"
+                f"error: peer result speaker mismatch (swap blocked)\npeer_raw={peer_result[:300]}"
+            )
+    # Prefer explicit as=REMOTE_ID in body
+    if "as=" in peer_result and f"as={REMOTE_ID}" not in peer_result:
+        return (
+            f"as={HOST_ID}\nself={post_self}\n"
+            f"error: peer result missing as={REMOTE_ID} (swap blocked)\npeer_raw={peer_result[:300]}"
+        )
+
+    peer_mid = parse_message_id(peer_result)
+    warn = monotonic_warning(mid, peer_mid)
+    if warn:
+        # Accept but escalate: countable log line for monitoring, flag in result
+        _log("warn", reason="monotonic", target=REMOTE_ID, self_mid=mid, peer_mid=peer_mid)
+        return (
+            f"as={HOST_ID}\ntarget={REMOTE_ID}\nself={post_self}\n"
+            f"peer={peer_result}\n{warn}"
+        )
+
+    return f"as={HOST_ID}\ntarget={REMOTE_ID}\nself={post_self}\npeer={peer_result}"
+
+
+async def _health(_request: Request) -> JSONResponse:
+    return JSONResponse({
+        "ok": True,
+        "protocol": PROTOCOL_VERSION,
+        "lab_id": HOST_ID,
+        "name": SELF_NAME,
+        "bot": SELF_BOT,
+        "bot_id": SELF_BOT_ID,
+        "remote": REMOTE_ID,
+        "remote_bot": REMOTE_BOT,
+        "style": "natural_chat",
+        "anti_swap": True,
+        "tools": [
+            "tag_peer", "ask_agent_group", "group_say", "am_i_addressed",
+            "ask_agent", "peer_status", "peer_identity",
+        ],
+    })
+
+
+async def _v1_ask_group(request: Request) -> JSONResponse:
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "invalid json"}, status_code=400)
+    prompt = (body or {}).get("prompt") or ""
+    from_lab = (body or {}).get("from_lab")
+    expect_lab = (body or {}).get("expect_lab")
+    # If caller says who should answer, it must be us
+    if expect_lab and str(expect_lab).strip().lower() != HOST_ID:
+        _log("reject", reason="expect_lab", expect_lab=expect_lab)
+        return JSONResponse(
+            {
+                "error": f"expect_lab={expect_lab} but this host is {HOST_ID}",
+                "lab_id": HOST_ID,
+            },
+            status_code=409,
+        )
+    rtm = (body or {}).get("reply_to_message_id")
+    try:
+        rtm_i = int(rtm) if rtm is not None else None
+    except Exception:
+        rtm_i = None
+    result = ask_agent_group(str(prompt), reply_to_message_id=rtm_i, from_lab=from_lab)
+    status = 200 if not str(result).startswith("error") else 500
+    return JSONResponse({"result": result, "lab_id": HOST_ID, "bot": SELF_BOT}, status_code=status)
+
+
+async def _v1_group_say(request: Request) -> JSONResponse:
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "invalid json"}, status_code=400)
+    result = group_say(str((body or {}).get("text") or ""))
+    status = 200 if not str(result).startswith("error") else 500
+    return JSONResponse({"result": result, "lab_id": HOST_ID, "bot": SELF_BOT}, status_code=status)
+
+
+async def _v1_tag_peer(request: Request) -> JSONResponse:
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "invalid json"}, status_code=400)
+    ask = (body or {}).get("ask") or (body or {}).get("prompt") or ""
+    result = tag_peer(str(ask))
+    status = 200 if not str(result).startswith("error") else 500
+    return JSONResponse({"result": result, "lab_id": HOST_ID, "bot": SELF_BOT}, status_code=status)
+
+
+def build_app():
+    app = mcp.streamable_http_app()
+    app.routes.insert(0, Route("/health", _health, methods=["GET"]))
+    app.routes.insert(0, Route("/v1/health", _health, methods=["GET"]))
+    app.routes.insert(0, Route("/v1/ask_group", _v1_ask_group, methods=["POST"]))
+    app.routes.insert(0, Route("/v1/group_say", _v1_group_say, methods=["POST"]))
+    app.routes.insert(0, Route("/v1/tag_peer", _v1_tag_peer, methods=["POST"]))
+    app.add_middleware(BearerAuthMiddleware)
+    return app
+
+
+if __name__ == "__main__":
+    print(
+        f"[peer-hermes-mcp] host={HOST_ID} bot=@{SELF_BOT} remote={REMOTE_ID} "
+        f"anti_swap=on url={REMOTE_URL}",
+        file=sys.stderr,
+        flush=True,
+    )
+    if _pair_err:
+        print(_pair_err, file=sys.stderr)
+        sys.exit(2)
+    import uvicorn
+    uvicorn.run(build_app(), host="0.0.0.0", port=PORT, log_level="warning")

--- a/tests/hermes_peer_mcp/test_peer_mcp_model.py
+++ b/tests/hermes_peer_mcp/test_peer_mcp_model.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+import unittest
+from peer_model import (
+    PROTOCOL_VERSION,
+    assert_bot_matches_lab,
+    assert_peer_pair,
+    assert_remote_health,
+    format_chat_outbound,
+    format_chat_reply,
+    is_addressed_to,
+    is_fast_ping,
+    monotonic_warning,
+    parse_message_id,
+    resolve_me,
+    should_alpha_free_respond,
+    validate_nonempty,
+)
+
+
+class TestNoSwapInvariants(unittest.TestCase):
+    def test_pair_ok(self):
+        self.assertIsNone(assert_peer_pair("alpha", "beta"))
+        self.assertIsNone(assert_peer_pair("beta", "alpha"))
+
+    def test_pair_rejects_self(self):
+        self.assertTrue(assert_peer_pair("alpha", "alpha").startswith("error"))
+
+    def test_pair_rejects_wrong_remote(self):
+        # alpha must not treat alpha as remote of alpha already covered;
+        # unknown remote
+        self.assertTrue(assert_peer_pair("alpha", "gamma").startswith("error"))
+
+    def test_bot_match(self):
+        self.assertIsNone(assert_bot_matches_lab("alpha", "erynoa_alpha_hermes_bot"))
+        self.assertIsNone(assert_bot_matches_lab("beta", "erynoa_beta_hermes_bot"))
+        err = assert_bot_matches_lab("alpha", "erynoa_beta_hermes_bot")
+        self.assertTrue(err.startswith("error: identity mismatch"))
+
+    def test_remote_health(self):
+        self.assertIsNone(assert_remote_health("alpha", "beta"))
+        self.assertTrue(assert_remote_health("alpha", "alpha").startswith("error"))
+        self.assertTrue(assert_remote_health("alpha", "gamma").startswith("error"))
+
+    def test_resolve_symmetric(self):
+        a, b = resolve_me("alpha"), resolve_me("beta")
+        self.assertEqual(a["remote_id"], "beta")
+        self.assertEqual(b["remote_id"], "alpha")
+        self.assertNotEqual(a["bot"], b["bot"])
+
+
+class TestAddressRule1(unittest.TestCase):
+    def test_mentions(self):
+        self.assertTrue(is_addressed_to("@erynoa_alpha_hermes_bot hi", "alpha"))
+        self.assertFalse(is_addressed_to("@erynoa_alpha_hermes_bot hi", "beta"))
+        self.assertTrue(is_addressed_to("frag beta", "beta"))
+        self.assertFalse(is_addressed_to("frag beta", "alpha"))
+
+    def test_plain_text_addresses_neither(self):
+        # T1: plain human text — no alias hit for either lab
+        self.assertFalse(is_addressed_to("wie geht es euch heute", "alpha"))
+        self.assertFalse(is_addressed_to("wie geht es euch heute", "beta"))
+
+    def test_both_mentioned(self):
+        # T4: both bots mentioned — both are addressed
+        both = "@erynoa_alpha_hermes_bot @erynoa_beta_hermes_bot status bitte"
+        self.assertTrue(is_addressed_to(both, "alpha"))
+        self.assertTrue(is_addressed_to(both, "beta"))
+
+    def test_reply_to_is_self(self):
+        # T5/T6: reply-to entity addresses the replied-to bot regardless of text
+        self.assertTrue(is_addressed_to("ok", "beta", reply_to_is_self=True))
+        self.assertFalse(is_addressed_to("ok", "beta", reply_to_is_self=False))
+
+    def test_explicit_mentions_param(self):
+        self.assertTrue(
+            is_addressed_to("kurz melden", "alpha", explicit_mentions=["@erynoa_alpha_hermes_bot"])
+        )
+        self.assertFalse(
+            is_addressed_to("kurz melden", "alpha", explicit_mentions=["@erynoa_beta_hermes_bot"])
+        )
+
+
+class TestFreeRespondLaw(unittest.TestCase):
+    """Protocol §4 — should_alpha_free_respond truth-table rows."""
+
+    def test_t1_plain_text(self):
+        self.assertTrue(should_alpha_free_respond("wie geht's euch"))
+
+    def test_prose_names_are_not_addresses(self):
+        # "frag beta online" is an instruction TO alpha, not an address of beta
+        self.assertTrue(should_alpha_free_respond("frag beta ob er online ist"))
+
+    def test_t3_exclusive_beta_mention(self):
+        self.assertFalse(
+            should_alpha_free_respond("mach du das", ["@erynoa_beta_hermes_bot"])
+        )
+
+    def test_t4_both_mentioned(self):
+        self.assertTrue(
+            should_alpha_free_respond(
+                "beide bitte", ["@erynoa_alpha_hermes_bot", "@erynoa_beta_hermes_bot"]
+            )
+        )
+
+    def test_t6_reply_to_beta(self):
+        self.assertFalse(
+            should_alpha_free_respond("und du?", reply_to_bot="erynoa_beta_hermes_bot")
+        )
+
+    def test_t5_reply_to_alpha(self):
+        self.assertTrue(
+            should_alpha_free_respond("und du?", reply_to_bot="erynoa_alpha_hermes_bot")
+        )
+
+    def test_bot_author_never_triggers(self):
+        self.assertFalse(should_alpha_free_respond("hallo", author_is_human=False))
+
+    def test_wrong_chat(self):
+        self.assertFalse(should_alpha_free_respond("hallo", chat_id="-123"))
+
+    def test_gamma_proof_other_bot_exclusive(self):
+        # future γ: exclusive mention of any other lab bot silences alpha
+        self.assertFalse(
+            should_alpha_free_respond("nur du", ["@erynoa_gamma_hermes_bot"])
+        )
+
+
+class TestMessageIdHelpers(unittest.TestCase):
+    def test_parse(self):
+        self.assertEqual(parse_message_id("posted chat=-5535276728 message_id=161 as=alpha"), 161)
+        self.assertIsNone(parse_message_id("error: telegram post failed"))
+
+    def test_monotonic(self):
+        self.assertIsNone(monotonic_warning(160, 161))
+        self.assertIsNotNone(monotonic_warning(161, 160))
+        self.assertIsNotNone(monotonic_warning(161, 161))
+        self.assertIsNone(monotonic_warning(None, 161))
+
+    def test_protocol_version(self):
+        self.assertRegex(PROTOCOL_VERSION, r"^\d+\.\d+\.\d+$")
+
+
+class TestChat(unittest.TestCase):
+    def test_outbound_targets_peer_only(self):
+        line = format_chat_outbound("hi", peer_bot="erynoa_beta_hermes_bot", peer_name="beta")
+        self.assertIn("@erynoa_beta_hermes_bot", line)
+        self.assertNotIn("alpha_hermes", line)
+        self.assertNotIn("PEER", line)
+
+    def test_reply_clean(self):
+        self.assertEqual(format_chat_reply("α: pong"), "pong")
+
+    def test_ping(self):
+        self.assertTrue(is_fast_ping("online?"))
+        self.assertIsNone(validate_nonempty("x"))
+
+
+
+class TestNoLabPrefix(unittest.TestCase):
+    def test_strips_greek_and_name(self):
+        from peer_model import clean_chat_text, format_chat_reply, fast_pong_text
+        self.assertEqual(format_chat_reply("α: hi there"), "hi there")
+        self.assertEqual(format_chat_reply("β: online"), "online")
+        self.assertEqual(format_chat_reply("Alpha: alles gut"), "alles gut")
+        self.assertEqual(format_chat_reply("beta — jo"), "jo")
+        self.assertNotIn("alpha", fast_pong_text("alpha").lower())
+        self.assertNotIn("beta", fast_pong_text("beta").lower())
+        self.assertNotIn("α", format_chat_reply("α pong"))
+        self.assertEqual(clean_chat_text("[beta] hey"), "hey")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Implements the ErynoaGroup elevation brief (W0–W5) for the tracked host side.

## What
- **tests/hermes_peer_mcp/**: peer MCP synced to pod baseline, then hardened — `should_alpha_free_respond` (protocol §4), pure `parse_message_id`/`monotonic_warning`, structured `[peer-mcp] event=` logs, `protocol` in `/v1/health`. **Tests 11 → 27, green.**
- **run_scenarios.sh**: config asserts A1–A4 + S6 wrong-`expect_lab` guard — **12/12 green against live pods**; S4/S5 live `tag_peer` round-trips behind `RUN_LIVE=1`; `deploy_to_labs.sh` ships to both pods.
- **docs/work/notes/**: multilab-AUDIT (drift register D1–D11), multilab-DEBT (blocked actions + promotion), multilab-ELEVATION (decisions + 48h backlog).

## Companion PRs
- `ErynoaGroup/.ai-harness` `lab-peer-protocol-v1` — Operating Protocol v1 + role refs
- `ErynoaGroup/.law` `lab-peer-mcp-first` — lab-peer always-on block fix

## Notes
- Branch is purely additive. `just test`'s 7 failing bash suites fail on `production` HEAD too (pre-existing, unrelated); erynoa-gate PASS.
- Pod deploy + live S4/S5 were permission-gated this session → `DEBT D-A/D-B`, each a one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hn5K8akwUsYssqjB8ty7Xv